### PR TITLE
Add Spigot's maven repo, so this is actually useful

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,5 +45,10 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
+    <repositories>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+   </repositories>
 </project>


### PR DESCRIPTION
How about we make this buildable across machines by actually using a maven repository to fetch the Bukkit dependency from