### PR TITLE
Fixed lots of errors if two players log in at the same time

### DIFF
--- a/src/main/java/us/myles/ViaVersion/handlers/ViaInboundHandler.java
+++ b/src/main/java/us/myles/ViaVersion/handlers/ViaInboundHandler.java
@@ -5,6 +5,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.socket.SocketChannel;
 import us.myles.ViaVersion.CancelException;
 import us.myles.ViaVersion.ConnectionInfo;
 import us.myles.ViaVersion.util.PacketUtil;
@@ -13,11 +14,17 @@ import us.myles.ViaVersion.transformers.IncomingTransformer;
 @ChannelHandler.Sharable
 public class ViaInboundHandler extends ChannelInboundHandlerAdapter {
     private final IncomingTransformer incomingTransformer;
-    private final ViaVersionInitializer init;
+    private final SocketChannel socketChannel;
 
-    public ViaInboundHandler(Channel c, ConnectionInfo info, ViaVersionInitializer init) {
-        this.init = init;
-        this.incomingTransformer = new IncomingTransformer(c, info, init);
+    public ViaInboundHandler(SocketChannel c, ConnectionInfo info) {
+        this.socketChannel = c;
+        this.incomingTransformer = new IncomingTransformer(this, c, info);
+    }
+    
+    public void remove(){
+        socketChannel.pipeline().remove("via_incoming");
+        socketChannel.pipeline().remove("via_outgoing");
+        socketChannel.pipeline().remove("via_outgoing2");
     }
 
     @Override

--- a/src/main/java/us/myles/ViaVersion/handlers/ViaVersionInitializer.java
+++ b/src/main/java/us/myles/ViaVersion/handlers/ViaVersionInitializer.java
@@ -8,13 +8,10 @@ import us.myles.ViaVersion.ConnectionInfo;
 import java.lang.reflect.Method;
 
 public class ViaVersionInitializer extends ChannelInitializer<SocketChannel> {
+	
+	// shared by all connections
     private final ChannelInitializer<SocketChannel> oldInit;
     private Method method;
-    private ConnectionInfo info;
-    private ViaInboundHandler inbound;
-    private ViaOutboundHandler outbound;
-    private SocketChannel socketChannel;
-    private ViaOutboundPacketHandler outbound2;
 
     public ViaVersionInitializer(ChannelInitializer<SocketChannel> oldInit) {
         this.oldInit = oldInit;
@@ -28,24 +25,18 @@ public class ViaVersionInitializer extends ChannelInitializer<SocketChannel> {
 
     @Override
     protected void initChannel(SocketChannel socketChannel) throws Exception {
-        info = new ConnectionInfo();
+    	ConnectionInfo info = new ConnectionInfo();
         // Add originals
         this.method.invoke(this.oldInit, socketChannel);
         // Add our transformers
-        this.socketChannel = socketChannel;
-        this.inbound = new ViaInboundHandler(socketChannel, info, this);
-        this.outbound = new ViaOutboundHandler(socketChannel, info, this);
-        this.outbound2 = new ViaOutboundPacketHandler(socketChannel, info);
-        socketChannel.pipeline().addBefore("decoder", "via_incoming", this.inbound);
-        socketChannel.pipeline().addBefore("packet_handler", "via_outgoing2", this.outbound2);
-        socketChannel.pipeline().addBefore("encoder", "via_outgoing", this.outbound);
+        
+        ViaInboundHandler inbound = new ViaInboundHandler(socketChannel, info);
+        ViaOutboundHandler outbound = new ViaOutboundHandler(socketChannel, info, this);
+        ViaOutboundPacketHandler outbound2 = new ViaOutboundPacketHandler(socketChannel, info);
+        socketChannel.pipeline().addBefore("decoder", "via_incoming", inbound);
+        socketChannel.pipeline().addBefore("packet_handler", "via_outgoing2", outbound2);
+        socketChannel.pipeline().addBefore("encoder", "via_outgoing", outbound);
 
-    }
-
-    public void remove(){
-        socketChannel.pipeline().remove("via_incoming");
-        socketChannel.pipeline().remove("via_outgoing");
-        socketChannel.pipeline().remove("via_outgoing2");
     }
 
 }

--- a/src/main/java/us/myles/ViaVersion/transformers/IncomingTransformer.java
+++ b/src/main/java/us/myles/ViaVersion/transformers/IncomingTransformer.java
@@ -1,27 +1,31 @@
 package us.myles.ViaVersion.transformers;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.bukkit.inventory.ItemStack;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
-import org.bukkit.inventory.ItemStack;
-import us.myles.ViaVersion.*;
-import us.myles.ViaVersion.handlers.ViaVersionInitializer;
+import us.myles.ViaVersion.CancelException;
+import us.myles.ViaVersion.ConnectionInfo;
+import us.myles.ViaVersion.ViaVersionPlugin;
+import us.myles.ViaVersion.handlers.ViaInboundHandler;
 import us.myles.ViaVersion.packets.PacketType;
 import us.myles.ViaVersion.packets.State;
 import us.myles.ViaVersion.util.PacketUtil;
 import us.myles.ViaVersion.util.ReflectionUtil;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
 public class IncomingTransformer {
+	
+	private final ViaInboundHandler handler;
     private final Channel channel;
     private final ConnectionInfo info;
-    private final ViaVersionInitializer init;
 
-    public IncomingTransformer(Channel channel, ConnectionInfo info, ViaVersionInitializer init) {
+    public IncomingTransformer(ViaInboundHandler viaInboundHandler, Channel channel, ConnectionInfo info) {
+    	this.handler = viaInboundHandler;
         this.channel = channel;
         this.info = info;
-        this.init = init;
     }
 
     public void transform(int packetID, ByteBuf input, ByteBuf output) throws CancelException {
@@ -48,8 +52,8 @@ public class IncomingTransformer {
             PacketUtil.writeVarInt(protVer <= 102 ? protVer : 47, output); // pretend to be older
 
             if (protVer <= 102) {
-                // Not 1.9 remove pipes
-                this.init.remove();
+                // not 1.9, remove pipes
+                this.handler.remove();
             }
             String serverAddress = PacketUtil.readString(input);
             PacketUtil.writeString(serverAddress, output);

--- a/src/main/java/us/myles/ViaVersion/transformers/OutgoingTransformer.java
+++ b/src/main/java/us/myles/ViaVersion/transformers/OutgoingTransformer.java
@@ -2,7 +2,6 @@ package us.myles.ViaVersion.transformers;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.sun.xml.internal.bind.v2.runtime.reflect.Lister;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import org.bukkit.entity.EntityType;


### PR DESCRIPTION
Netty should not store a players pipeline handler in a public field which is not specific for that connection, fixed.