### PR TITLE
Fixed horses inventory/elytra exception

### DIFF
--- a/src/main/java/us/myles/ViaVersion/transformers/IncomingTransformer.java
+++ b/src/main/java/us/myles/ViaVersion/transformers/IncomingTransformer.java
@@ -163,6 +163,19 @@ public class IncomingTransformer {
             PacketUtil.readVarInt(input);
             return;
         }
+        if (packet == PacketType.PLAY_ENTITY_ACTION) {
+            int playerId = PacketUtil.readVarInt(input);
+            int action = PacketUtil.readVarInt(input);
+            int jump = PacketUtil.readVarInt(input);
+            if (action == 6 || action == 8) //Ignore stop jumping / start elytra flying
+                throw new CancelException();
+            if (action == 7) //Change open horse inventory to the 1.8 value
+                action = 6;
+            PacketUtil.writeVarInt(playerId, output);
+            PacketUtil.writeVarInt(action, output);
+            PacketUtil.writeVarInt(jump, output);
+            return;
+        }
         if (packet == PacketType.PLAY_USE_ENTITY) {
             int target = PacketUtil.readVarInt(input);
             PacketUtil.writeVarInt(target, output);


### PR DESCRIPTION
Fix exception on opening horses inventory / elytra 

[19:30:26] [Netty Server IO #0/WARN]: Caused by: java.lang.ArrayIndexOutOfBoundsException: 7
[19:30:26] [Netty Server IO #0/WARN]: 	at net.minecraft.server.v1_8_R3.PacketDataSerializer.a(PacketDataSerializer.java:73)
[19:30:26] [Netty Server IO #0/WARN]: 	at net.minecraft.server.v1_8_R3.PacketPlayInEntityAction.a(SourceFile:30)
[19:30:26] [Netty Server IO #0/WARN]: 	at net.minecraft.server.v1_8_R3.PacketDecoder.decode(SourceFile:40)
[19:30:26] [Netty Server IO #0/WARN]: 	... 37 more
