### PR TITLE
Manually perform idle updates. Fixed #160 #99

### DIFF
--- a/src/main/java/us/myles/ViaVersion/ViaIdleThread.java
+++ b/src/main/java/us/myles/ViaVersion/ViaIdleThread.java
@@ -1,0 +1,42 @@
+package us.myles.ViaVersion;
+
+import org.bukkit.scheduler.BukkitRunnable;
+import us.myles.ViaVersion.api.ViaVersion;
+import us.myles.ViaVersion.util.ReflectionUtil;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class ViaIdleThread extends BukkitRunnable {
+    private final Map<UUID, ConnectionInfo> portedPlayers;
+    private final Class<?> idlePacketClass;
+
+    public ViaIdleThread(Map<UUID, ConnectionInfo> portedPlayers) {
+        this.portedPlayers = portedPlayers;
+        try {
+            this.idlePacketClass = ReflectionUtil.nms("PacketPlayInFlying");
+        } catch(ClassNotFoundException e) {
+            throw new RuntimeException("Couldn't find player idle packet, help!", e);
+        }
+    }
+
+    @Override
+    public void run() {
+        for(ConnectionInfo info : portedPlayers.values()) {
+            long nextIdleUpdate = info.getNextIdlePacket();
+            if(nextIdleUpdate <= System.currentTimeMillis()) {
+                try {
+                    Object packet = idlePacketClass.newInstance();
+                    info.getChannel().pipeline().fireChannelRead(packet);
+                } catch(InstantiationException | IllegalAccessException e) {
+                    System.out.println("Failed to create idle packet.");
+                    if(ViaVersion.getInstance().isDebug()) {
+                        e.printStackTrace();
+                    }
+                } finally {
+                    info.incrementIdlePacket();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
+++ b/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
@@ -73,6 +73,7 @@ public class ViaVersionPlugin extends JavaPlugin implements ViaVersionAPI {
 
         getLogger().info("ViaVersion " + getDescription().getVersion() + " is now enabled, injecting. (Allows 1.8 to be accessed via 1.9)");
         injectPacketHandler();
+        new ViaIdleThread(portedPlayers).runTaskTimerAsynchronously(this, 1L, 1L); // Updates player's idle status
 
         if (getConfig().getBoolean("checkforupdates"))
             UpdateUtil.sendUpdateMessage(this);

--- a/src/main/java/us/myles/ViaVersion/handlers/ViaDecodeHandler.java
+++ b/src/main/java/us/myles/ViaVersion/handlers/ViaDecodeHandler.java
@@ -38,6 +38,11 @@ public class ViaDecodeHandler extends ByteToMessageDecoder {
                     bytebuf.clear();
                     throw e;
                 }
+
+                // Update idle status (player, position, look, positionandlook)
+                if(id == 0x0F || id == 0x0E || id == 0x0D || id == 0x0C) {
+                    info.incrementIdlePacket();
+                }
             }
             // call minecraft decoder
             list.addAll(PacketUtil.callDecode(this.minecraftDecoder, ctx, bytebuf));


### PR DESCRIPTION
Manually performs idle updates by keeping track of the player's
movement.
It compensates for the missing idle packets attempting to get a ratio of
20 movement related packets per second.