### PR TITLE
Make it possible to use the new effect indicators in 1.9

### DIFF
--- a/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
+++ b/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
@@ -239,6 +239,10 @@ public class ViaVersionPlugin extends JavaPlugin implements ViaVersionAPI {
         return getConfig().getBoolean("prevent-collision", true);
     }
 
+    public boolean isNewEffectIndicator(){
+        return getConfig().getBoolean("use-new-effect-indicator",true);
+    }
+
     public boolean isSuppressMetadataErrors() {
         return getConfig().getBoolean("suppress-metadata-errors", false);
     }

--- a/src/main/java/us/myles/ViaVersion/transformers/OutgoingTransformer.java
+++ b/src/main/java/us/myles/ViaVersion/transformers/OutgoingTransformer.java
@@ -679,7 +679,7 @@ public class OutgoingTransformer {
             PacketUtil.writeVarInt(duration, output);
             // we need to write as a byte instead of boolean
             boolean hideParticles = input.readBoolean();
-            output.writeByte(hideParticles ? 1 : 0);
+            output.writeByte(hideParticles ? plugin.isNewEffectIndicator() ? 2 : 1 : 0);
             return;
         }
         if (packet == PacketType.PLAY_TEAM) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,3 +20,5 @@ simulate-pt: true
 bossbar-patch: true
 # If your boss bar flickers on 1.9, set this to 'true'. It will keep all boss bars on 100% (not recommended)
 bossbar-anti-flicker: false
+# This will show the new effect indicator in the top-right corner for 1.9 players.
+use-new-effect-indicator: true


### PR DESCRIPTION
Let users choose to use the new effect indicators in 1.9
This will not support the new beacon glowing effect

http://wiki.vg/Protocol#Entity_Effect
Particle byte enum has to be:

Type | Value
------------ | -------------
0 | Show particles
1 | Hide particles
2 | Show particles & Effect indicator (Used for potions)
3 | Hide particles & Effect indicator with glow (Used for beacons)

If someone wants to change/report that at wiki.vg. Please go ahead :)