### PR TITLE
Show skeletons bow like 1.8, not down as 1.9 without target

### DIFF
--- a/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/EntityTracker.java
+++ b/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/storage/EntityTracker.java
@@ -22,6 +22,7 @@ import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.minecraft.metadata.Metadata;
 import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.protocols.base.ProtocolInfo;
+import us.myles.ViaVersion.protocols.protocol1_9to1_8.metadata.NewType;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -123,6 +124,12 @@ public class EntityTracker extends StoredObject {
                 if (metadata.getId() == 11) {
                     metadataList.remove(metadata);
                     //   metadataList.add(new Metadata(11, NewType.Byte.getTypeID(), Type.VAR_INT, 0));
+                }
+            }
+
+            if (type == EntityType.SKELETON) {
+                if ((getMetaByIndex(metadataList, 12)) == null) {
+                    metadataList.add(new Metadata(12, NewType.Boolean.getTypeID(), Type.BOOLEAN, true));
                 }
             }
 


### PR DESCRIPTION
According to wiki.vg, this metadata only impacts the swing, but according to my research, it only impacts the bow, not 100% sure. But wither skeletons were still able to swing.
http://wiki.vg/Entities#Skeleton