### PR TITLE
Don't unload chunks twice

### DIFF
--- a/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/ChunkType.java
+++ b/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/ChunkType.java
@@ -128,15 +128,11 @@ public class ChunkType extends PartialType<Chunk, ClientChunks> {
 
     @Override
     public void write(ByteBuf output, ClientChunks param, Chunk chunk) throws Exception {
-        if (chunk.isUnloadPacket()) {
-            output.clear();
-            Type.VAR_INT.write(output, 0x1D); // Unload packet ID
-        }
+        if (chunk.isUnloadPacket()) return;
 
         // Write primary info
         output.writeInt(chunk.getX());
         output.writeInt(chunk.getZ());
-        if (chunk.isUnloadPacket()) return;
         output.writeByte(chunk.isGroundUp() ? 0x01 : 0x00);
         Type.VAR_INT.write(output, chunk.getPrimaryBitmask());
 


### PR DESCRIPTION
You unload it here:
https://github.com/MylesIsCool/ViaVersion/blob/master/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/ChunkType.java#L131-L134

And over here:
https://github.com/MylesIsCool/ViaVersion/blob/master/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/WorldPackets.java#L119-L125

That was not the case in 0.6.7

@gigosaurus Could you test if #338 still happens?