### PR TITLE
Fix brewing item showing twice, one in the new slot one in the old

### DIFF
--- a/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
+++ b/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/InventoryPackets.java
@@ -146,10 +146,10 @@ public class InventoryPackets {
                                 Item[] oldStack = wrapper.get(Type.ITEM_ARRAY, 0);
                                 Item[] newStack = new Item[oldStack.length + 1];
                                 for (int i = 0; i < newStack.length; i++) {
-                                    if (i > 3) {
+                                    if (i > 4) {
                                         newStack[i] = oldStack[i - 1];
                                     } else {
-                                        if (i != 3) { // Leave index 3 blank
+                                        if (i != 4) { // Leave index 3 blank
                                             newStack[i] = oldStack[i];
                                         }
                                     }


### PR DESCRIPTION
If you opened the inventory with items in the slots, you'd see it twice, one real, one fake. probably won't fix #358 but it's a bug I found