### PR TITLE
Update names from 'snapshot' to '1.10'

### DIFF
--- a/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
+++ b/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
@@ -34,7 +34,7 @@ public class ProtocolRegistry {
         // Only supported for 1.9.4 server to 1.9 (nothing else)
         registerProtocol(new Protocol1_9TO1_9_1(), Arrays.asList(ProtocolVersion.v1_9.getId()), ProtocolVersion.v1_9_2.getId());
         registerProtocol(new Protocol1_9_1_2TO1_9_3_4(), Arrays.asList(ProtocolVersion.v1_9_1.getId(), ProtocolVersion.v1_9_2.getId()), ProtocolVersion.v1_9_3.getId());
-        registerProtocol(new Protocol1_10To1_9_3_4(), Collections.singletonList(ProtocolVersion.SNAPSHOT.getId()), ProtocolVersion.v1_9_3.getId());
+        registerProtocol(new Protocol1_10To1_9_3_4(), Collections.singletonList(ProtocolVersion.v1_10.getId()), ProtocolVersion.v1_9_3.getId());
 
     }
 

--- a/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolVersion.java
+++ b/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolVersion.java
@@ -16,7 +16,7 @@ public class ProtocolVersion {
     public static final ProtocolVersion v1_9_1;
     public static final ProtocolVersion v1_9_2;
     public static final ProtocolVersion v1_9_3;
-    public static final ProtocolVersion SNAPSHOT;
+    public static final ProtocolVersion v1_10;
 
     private final int id;
     private final String name;
@@ -29,7 +29,7 @@ public class ProtocolVersion {
         register(v1_9_1 = new ProtocolVersion(108, "1.9.1"));
         register(v1_9_2 = new ProtocolVersion(109, "1.9.2"));
         register(v1_9_3 = new ProtocolVersion(110, "1.9.3/4"));
-        register(SNAPSHOT = new ProtocolVersion(210, "1.10"));
+        register(v1_10 = new ProtocolVersion(210, "1.10"));
     }
 
     public static void register(@NonNull ProtocolVersion protocol) {

--- a/src/main/java/us/myles/ViaVersion/protocols/protocol1_10to1_9_3/Protocol1_10To1_9_3_4.java
+++ b/src/main/java/us/myles/ViaVersion/protocols/protocol1_10to1_9_3/Protocol1_10To1_9_3_4.java
@@ -10,14 +10,14 @@ import us.myles.ViaVersion.api.remapper.ValueTransformer;
 import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.packets.State;
 import us.myles.ViaVersion.protocols.protocol1_10to1_9_3.storage.ResourcePackTracker;
-import us.myles.ViaVersion.protocols.protocol1_10to1_9_3.types.MetaListSnapshotType;
-import us.myles.ViaVersion.protocols.protocol1_10to1_9_3.types.MetaSnapshotType;
+import us.myles.ViaVersion.protocols.protocol1_10to1_9_3.types.MetaList1_10Type;
+import us.myles.ViaVersion.protocols.protocol1_10to1_9_3.types.Meta1_10Type;
 
 import java.util.List;
 
 public class Protocol1_10To1_9_3_4 extends Protocol {
-    public static final Type<List<Metadata>> METADATA_LIST = new MetaListSnapshotType();
-    public static final Type<Metadata> METADATA = new MetaSnapshotType();
+    public static final Type<List<Metadata>> METADATA_LIST = new MetaList1_10Type();
+    public static final Type<Metadata> METADATA = new Meta1_10Type();
     public static ValueTransformer<Short, Float> toNewPitch = new ValueTransformer<Short, Float>(Type.FLOAT) {
         @Override
         public Float transform(PacketWrapper wrapper, Short inputValue) throws Exception {

--- a/src/main/java/us/myles/ViaVersion/protocols/protocol1_10to1_9_3/types/Meta1_10Type.java
+++ b/src/main/java/us/myles/ViaVersion/protocols/protocol1_10to1_9_3/types/Meta1_10Type.java
@@ -5,7 +5,7 @@ import us.myles.ViaVersion.api.minecraft.metadata.Metadata;
 import us.myles.ViaVersion.api.type.types.minecraft.MetaTypeTemplate;
 import us.myles.ViaVersion.protocols.protocol1_9to1_8.metadata.NewType;
 
-public class MetaSnapshotType extends MetaTypeTemplate {
+public class Meta1_10Type extends MetaTypeTemplate {
 
     @Override
     public Metadata read(ByteBuf buffer) throws Exception {

--- a/src/main/java/us/myles/ViaVersion/protocols/protocol1_10to1_9_3/types/MetaList1_10Type.java
+++ b/src/main/java/us/myles/ViaVersion/protocols/protocol1_10to1_9_3/types/MetaList1_10Type.java
@@ -10,7 +10,7 @@ import us.myles.ViaVersion.protocols.protocol1_9to1_8.metadata.NewType;
 import java.util.ArrayList;
 import java.util.List;
 
-public class MetaListSnapshotType extends MetaListTypeTemplate {
+public class MetaList1_10Type extends MetaListTypeTemplate {
 
     @Override
     public List<Metadata> read(ByteBuf buffer) throws Exception {


### PR DESCRIPTION
Some classes and variable names are still "snapshot", so I've changed them to "1.10"