### PR TITLE
Correct hologram Y offset

### DIFF
--- a/src/main/java/us/myles/ViaVersion/ViaConfig.java
+++ b/src/main/java/us/myles/ViaVersion/ViaConfig.java
@@ -87,7 +87,7 @@ public class ViaConfig implements ViaVersionConfig {
 
     @Override
     public double getHologramYOffset() {
-        return plugin.getConfig().getDouble("hologram-y", -1D);
+        return plugin.getConfig().getDouble("hologram-y", -0.96D);
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -54,7 +54,7 @@ shield-blocking: true
 # If they're in the wrong place enable this
 hologram-patch: false
 # This is the offset, should work as default when enabled.
-hologram-y: -1
+hologram-y: -0.96
 # Enable player tick simulation, this fixes eating, drinking, nether portals.
 simulate-pt: true
 # Should we use nms player to simulate packets, (may fix anti-cheat issues)


### PR DESCRIPTION
https://github.com/filoghost/HolographicDisplays/blob/master/HolographicDisplays/Plugin/com/gmail/filoghost/holographicdisplays/util/Offsets.java#L15 The offset is by default -1.25 for 1.8, however 1.9 clients require only -0.29. (-1.25 - -0.29) = -0.96 which should be the correct offset.