### PR TITLE
Fix wrong package name when shading libraries

### DIFF
--- a/jar/pom.xml
+++ b/jar/pom.xml
@@ -47,15 +47,15 @@
                     <relocations>
                         <relocation>
                             <pattern>org.spacehq.opennbt</pattern>
-                            <shadedPattern>us.myles.viaversion.libs.opennbt</shadedPattern>
+                            <shadedPattern>us.myles.ViaVersion.libs.opennbt</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>com.google.gson</pattern>
-                            <shadedPattern>us.myles.viaversion.libs.gson</shadedPattern>
+                            <shadedPattern>us.myles.ViaVersion.libs.gson</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>org.javassist</pattern>
-                            <shadedPattern>us.myles.viaversion.libs.javassist</shadedPattern>
+                            <shadedPattern>us.myles.ViaVersion.libs.javassist</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>


### PR DESCRIPTION
In the jar `pom.xml`, the shadedPattern's Package Name was set to `viaversion`, but in every other module the Package name was `ViaVersion`. This resulted in a quite wierd Package hierarchy when decompiling the Plugin. This Pull Request fixes this.
![Image](http://image.prntscr.com/image/6dc3bfa9d05c4e3b937165eedfc669f7.png)