### PR TITLE
Fixing item count on 1.11, where size <= 0. (#553)

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/ItemRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/ItemRewriter.java
@@ -97,7 +97,7 @@ public class ItemRewriter {
                 }
             }
         }
-        if (stack.getAmount() <= 0) stack.setAmount((byte) 1);
+        if (item.getAmount() <= 0) item.setAmount((byte) 1);
     }
 
     public static void toServer(Item item) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/ItemRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_11to1_10/ItemRewriter.java
@@ -97,6 +97,7 @@ public class ItemRewriter {
                 }
             }
         }
+        if (stack.getAmount() <= 0) stack.setAmount((byte) 1);
     }
 
     public static void toServer(Item item) {


### PR DESCRIPTION
This will change all items with negative or zero amount, so the 1.11 client can display them.