### PR TITLE
[WIP] Add bStats as a metrics service, implements #658

### DIFF
--- a/.idea/dictionaries/Martin.xml
+++ b/.idea/dictionaries/Martin.xml
@@ -1,0 +1,3 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="Martin" />
+</component>

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -60,5 +60,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- bStats -->
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>${bstatsVersion}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/bukkit/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
@@ -2,6 +2,7 @@ package us.myles.ViaVersion;
 
 import com.google.gson.JsonObject;
 import lombok.Getter;
+import org.bstats.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
@@ -23,6 +24,7 @@ import us.myles.ViaVersion.dump.PluginInfo;
 import us.myles.ViaVersion.util.GsonUtil;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -119,6 +121,8 @@ public class ViaVersionPlugin extends JavaPlugin implements ViaPlatform {
             Bukkit.getScheduler().runTaskAsynchronously(this, r);
         }
         asyncQueuedTasks.clear();
+
+        setupMetrics();
     }
 
     @Override
@@ -257,5 +261,21 @@ public class ViaVersionPlugin extends JavaPlugin implements ViaPlatform {
     @Override
     public boolean isOldClientsAllowed() {
         return !protocolSupport; // Use protocolsupport for older clients
+    }
+
+    // IntelliJ complains about duplicates, its the same code but with different bStats modules...
+    @SuppressWarnings("Duplicates")
+    private void setupMetrics() {
+        try {
+            Metrics metrics = new Metrics(this);
+            metrics.addCustomChart(new Metrics.AdvancedPie("protocol_versions") {
+                @Override
+                public HashMap<String, Integer> getValues(HashMap<String, Integer> valueMap) {
+                    return Via.getManager().getMetrics(valueMap);
+                }
+            });
+        } catch (Exception ex) {
+            Via.getPlatform().getLogger().warning("Error while enabling metrics! " + ex.getClass().getName() + ": " + ex.getMessage());
+        }
     }
 }

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -39,5 +39,12 @@
             <artifactId>viaversion-common</artifactId>
             <version>1.0.5-SNAPSHOT</version>
         </dependency>
+
+        <!-- bStats-->
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bungeecord</artifactId>
+            <version>${bstatsVersion}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/bungee/src/main/java/us/myles/ViaVersion/BungeePlugin.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/BungeePlugin.java
@@ -8,6 +8,7 @@ import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.event.EventHandler;
+import org.bstats.Metrics;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.ViaAPI;
 import us.myles.ViaVersion.api.command.ViaCommandSender;
@@ -24,6 +25,7 @@ import us.myles.ViaVersion.util.GsonUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +54,8 @@ public class BungeePlugin extends Plugin implements ViaPlatform, Listener {
     public void onEnable() {
         // Inject
         Via.getManager().init();
+
+        setupMetrics();
     }
 
     @Override
@@ -163,5 +167,21 @@ public class BungeePlugin extends Plugin implements ViaPlatform, Listener {
     @EventHandler
     public void onQuit(PlayerDisconnectEvent e) {
         Via.getManager().removePortedClient(e.getPlayer().getUniqueId());
+    }
+
+    // IntelliJ complains about duplicates, its the same code but with different bStats modules...
+    @SuppressWarnings("Duplicates")
+    private void setupMetrics() {
+        try {
+            Metrics metrics = new Metrics(this);
+            metrics.addCustomChart(new Metrics.AdvancedPie("protocol_versions") {
+                @Override
+                public HashMap<String, Integer> getValues(HashMap<String, Integer> valueMap) {
+                    return Via.getManager().getMetrics(valueMap);
+                }
+            });
+        } catch (Exception ex) {
+            Via.getPlatform().getLogger().warning("Error while enabling metrics! " + ex.getClass().getName() + ": " + ex.getMessage());
+        }
     }
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.18-SNAPSHOT</version>
+            <version>1.19</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/common/src/main/java/us/myles/ViaVersion/ViaManager.java
+++ b/common/src/main/java/us/myles/ViaVersion/ViaManager.java
@@ -3,6 +3,8 @@ package us.myles.ViaVersion;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import us.myles.ViaVersion.api.Via;
+import us.myles.ViaVersion.api.command.ViaCommandSender;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.platform.ViaInjector;
 import us.myles.ViaVersion.api.platform.ViaPlatform;
@@ -14,6 +16,7 @@ import us.myles.ViaVersion.commands.ViaCommandHandler;
 import us.myles.ViaVersion.protocols.base.ProtocolInfo;
 import us.myles.ViaVersion.update.UpdateUtil;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -116,4 +119,19 @@ public class ViaManager {
         return portedPlayers.get(playerUUID);
     }
 
+    /**
+     * Collects the protocol versions of all online players and puts them into the valueMap, ready to be send to the metrics service
+     *
+     * @param valueMap the map where the data should be inserted into
+     * @return the valueMap with the added values
+     */
+    public HashMap<String, Integer> getMetrics(HashMap<String, Integer> valueMap) {
+        for (ViaCommandSender p : Via.getPlatform().getOnlinePlayers()) {
+            int playerVersion = Via.getAPI().getPlayerVersion(p.getUUID());
+            ProtocolVersion key = ProtocolVersion.getProtocol(playerVersion);
+            Integer count = valueMap.get(key.getName());
+            valueMap.put(key.getName(), count == null ? 0 : ++count);
+        }
+        return valueMap;
+    }
 }

--- a/jar/pom.xml
+++ b/jar/pom.xml
@@ -57,6 +57,10 @@
                             <pattern>org.javassist</pattern>
                             <shadedPattern>us.myles.viaversion.libs.javassist</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>org.bstats</pattern>
+                            <shadedPattern>us.myles.viaversion.libs.org.bstats</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <project.build.outputEncoding>${projectEncoding}</project.build.outputEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
+        <bstatsVersion>1.1</bstatsVersion>
     </properties>
 
     <repositories>
@@ -44,16 +45,16 @@
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots</url>
         </repository>
 
-        <!-- SpaceHQ Repo-->
-        <repository>
-            <id>spacehq-repo</id>
-            <url>https://repo.spacehq.org/content/repositories/releases/</url>
-        </repository>
-
         <!-- Bungee repo -->
         <repository>
             <id>bungeecord-repo</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+
+        <!-- bStats Repo -->
+        <repository>
+            <id>bstats-repo</id>
+            <url>http://repo.bstats.org/content/repositories/releases/</url>
         </repository>
     </repositories>
 
@@ -117,5 +118,4 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -86,6 +86,12 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
-    </dependencies>
 
+        <!-- bStats -->
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-sponge</artifactId>
+            <version>${bstatsVersion}</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/sponge/src/main/java/us/myles/ViaVersion/SpongePlugin.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/SpongePlugin.java
@@ -2,6 +2,7 @@ package us.myles.ViaVersion;
 
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
+import org.bstats.Metrics;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.config.DefaultConfig;
 import org.spongepowered.api.entity.living.player.Player;
@@ -26,10 +27,7 @@ import us.myles.ViaVersion.sponge.util.LoggerWrapper;
 import us.myles.ViaVersion.util.GsonUtil;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
@@ -46,6 +44,9 @@ public class SpongePlugin implements ViaPlatform {
 
     @Inject
     private PluginContainer container;
+
+    @Inject
+    private Metrics metrics;
 
     @Inject
     @DefaultConfig(sharedRoot = false)
@@ -78,6 +79,8 @@ public class SpongePlugin implements ViaPlatform {
 
         // Inject!
         Via.getManager().init();
+
+        setupMetrics();
     }
 
     @Override
@@ -203,5 +206,20 @@ public class SpongePlugin implements ViaPlatform {
     @Override
     public boolean isOldClientsAllowed() {
         return true;
+    }
+
+    // IntelliJ complains about duplicates, its the same code but with different bStats modules...
+    @SuppressWarnings("Duplicates")
+    private void setupMetrics() {
+        try {
+            metrics.addCustomChart(new Metrics.AdvancedPie("protocol_versions") {
+                @Override
+                public HashMap<String, Integer> getValues(HashMap<String, Integer> valueMap) {
+                    return Via.getManager().getMetrics(valueMap);
+                }
+            });
+        } catch (Exception ex) {
+            Via.getPlatform().getLogger().warning("Error while enabling metrics! " + ex.getClass().getName() + ": " + ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
# Info

As explained in #658 bStats is basically the replacement for mcstats.org.

This pr implements the metric service for all 3 platforms and also adds a custom chart to track protocol versions of connected players. 
You will have to sign up @ bstats.org, add the plugin and configure the custom graph (its a 'Advanced Pie' named 'protocol_versions'), see [here](https://bstats.org/add-plugin) and [here](https://bstats.org/help/custom-charts)

# What data will be send?
From bStats.org:
```
By default, bStats sends the following data:
- Your server's randomly generated UUID
- The amount of players on your server
- The online mode of your server
- The bukkit version of your server
- The java version of your system (e.g. Java 8)
- The name of your OS (e.g. Windows)
- The version of your OS
- The architecture of your OS (e.g. amd64)
- The system cores of your OS (e.g. 8)
- bStats-supported plugins
- Plugin version of bStats-supported plugins
```
this PR will additional send the protocol version of all connected players.

All data collection can be disabled by the server admin by opting out in the bStats config: plugins/bStats/config.yml 

# Status
This PR is currently completely untested as I cannot build via (see gitter).  
Once that is fixed, I need to test all platforms with multiple versions.  
I am also unsure if the relocation works like that. Needs testing once I can build.