### PR TITLE
Format the book data correctly, fixes #737 + spaces

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/ItemRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/ItemRewriter.java
@@ -186,6 +186,41 @@ public class ItemRewriter {
             }
         }
     }
+    
+    public static void rewriteBookToServer(Item item) {
+        short id = item.getId();
+        if (id != 387) {
+            return;
+        }
+        CompoundTag tag = item.getTag();
+        ListTag pages = tag.get("pages");
+        if (pages == null) { // is this even possible?
+            return;
+        }
+        for (int i = 0; i < pages.size(); i++) {
+            Tag pageTag = pages.get(i);
+            if (!(pageTag instanceof StringTag)) {
+                continue;
+            }
+            StringTag stag = (StringTag) pageTag;
+            String value = stag.getValue();
+            if (value.replaceAll(" ", "").isEmpty()) {
+                value = "\"" + fixBookSpaceChars(value) + "\"";
+            } else {
+                value = fixBookSpaceChars(value);
+            }
+            stag.setValue(value);
+        }
+    }
+    
+    private static String fixBookSpaceChars(String str) {
+        if (!str.startsWith(" ")) {
+            return str;
+        }
+        // hacky but it works :)
+        str = "\u00A7r" + str;
+        return str;
+    }
 
     public static void toClient(Item item) {
         if (item != null) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
@@ -500,7 +500,7 @@ public class PlayerPackets {
                         String name = wrapper.get(Type.STRING, 0);
                         if (name.equalsIgnoreCase("MC|BSign")) {
                             Item item = wrapper.passthrough(Type.ITEM);
-                            if (item != null) { //TODO: HERE
+                            if (item != null) {
                                 item.setId((short) 387); // Written Book
                                 ItemRewriter.rewriteBookToServer(item);
                             }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/packets/PlayerPackets.java
@@ -500,8 +500,9 @@ public class PlayerPackets {
                         String name = wrapper.get(Type.STRING, 0);
                         if (name.equalsIgnoreCase("MC|BSign")) {
                             Item item = wrapper.passthrough(Type.ITEM);
-                            if (item != null) {
+                            if (item != null) { //TODO: HERE
                                 item.setId((short) 387); // Written Book
+                                ItemRewriter.rewriteBookToServer(item);
                             }
                         }
                         if (name.equalsIgnoreCase("MC|AutoCmd")) {


### PR DESCRIPTION
1.8 clients insert quotes at the start and end of an empty string. However 1.9+ clients no longer do that so we've to do it manually because the chat serializer doesn't like empty strings. 
Formating the book data correctly fixes #737 and spaces randomly disappearing before the first character of each page. (annoying when trying to position text on a [page](https://youtu.be/IdjW2KkMhVY).
Tested on a 1.8.8 spigot server with 1.9 and 1.12.2 clients.