### PR TITLE
Improve inventory handling for Bukkit servers

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/ViaVersionPlugin.java
@@ -175,6 +175,11 @@ public class ViaVersionPlugin extends JavaPlugin implements ViaPlatform {
     }
 
     @Override
+    public TaskId runSync(Runnable runnable, Long ticks) {
+        return new BukkitTaskId(getServer().getScheduler().runTaskLater(this, runnable, ticks).getTaskId());
+    }
+
+    @Override
     public TaskId runRepeatingSync(Runnable runnable, Long ticks) {
         return new BukkitTaskId(getServer().getScheduler().runTaskTimer(this, runnable, ticks, 0).getTaskId());
     }

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitConfigAPI.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitConfigAPI.java
@@ -164,6 +164,11 @@ public class BukkitConfigAPI extends Config implements ViaVersionConfig {
     public boolean is1_12NBTArrayFix() {
         return getBoolean("chat-nbt-fix", true);
     }
+    
+    @Override
+    public boolean is1_12QuickMoveActionFix() {
+        return getBoolean("quick-move-action-fix", true);
+    }
 
     @Override
     public List<Integer> getBlockedProtocols() {

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaLoader.java
@@ -14,11 +14,11 @@ import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.platform.ViaPlatformLoader;
 import us.myles.ViaVersion.bukkit.listeners.UpdateListener;
 import us.myles.ViaVersion.bukkit.listeners.protocol1_9to1_8.*;
-import us.myles.ViaVersion.bukkit.providers.BukkitInvContainerItemProvider;
+import us.myles.ViaVersion.bukkit.providers.BukkitInventoryQuickMoveProvider;
 import us.myles.ViaVersion.bukkit.providers.BukkitViaBulkChunkTranslator;
 import us.myles.ViaVersion.bukkit.providers.BukkitViaMovementTransmitter;
 import us.myles.ViaVersion.protocols.base.ProtocolInfo;
-import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.providers.InvContainerItemProvider;
+import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.providers.InventoryQuickMoveProvider;
 import us.myles.ViaVersion.protocols.protocol1_9to1_8.providers.BulkChunkTranslatorProvider;
 import us.myles.ViaVersion.protocols.protocol1_9to1_8.providers.HandItemProvider;
 import us.myles.ViaVersion.protocols.protocol1_9to1_8.providers.MovementTransmitterProvider;
@@ -65,7 +65,7 @@ public class BukkitViaLoader implements ViaPlatformLoader {
         Via.getManager().getProviders().use(BulkChunkTranslatorProvider.class, new BukkitViaBulkChunkTranslator());
         Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BukkitViaMovementTransmitter());
         if (plugin.getConf().is1_12QuickMoveActionFix()) {
-            Via.getManager().getProviders().use(InvContainerItemProvider.class, new BukkitInvContainerItemProvider());
+            Via.getManager().getProviders().use(InventoryQuickMoveProvider.class, new BukkitInventoryQuickMoveProvider());
         }
         Via.getManager().getProviders().use(HandItemProvider.class, new HandItemProvider() {
             @Override

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaLoader.java
@@ -64,7 +64,9 @@ public class BukkitViaLoader implements ViaPlatformLoader {
         /* Providers */
         Via.getManager().getProviders().use(BulkChunkTranslatorProvider.class, new BukkitViaBulkChunkTranslator());
         Via.getManager().getProviders().use(MovementTransmitterProvider.class, new BukkitViaMovementTransmitter());
-        Via.getManager().getProviders().use(InvContainerItemProvider.class, new BukkitInvContainerItemProvider());
+        if (plugin.getConf().is1_12QuickMoveActionFix()) {
+            Via.getManager().getProviders().use(InvContainerItemProvider.class, new BukkitInvContainerItemProvider());
+        }
         Via.getManager().getProviders().use(HandItemProvider.class, new HandItemProvider() {
             @Override
             public Item getHandItem(final UserConnection info) {

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/protocol1_12to1_11_1/BukkitInvContainerUpdateTask.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/protocol1_12to1_11_1/BukkitInvContainerUpdateTask.java
@@ -20,7 +20,7 @@ public class BukkitInvContainerUpdateTask implements Runnable {
     public BukkitInvContainerUpdateTask(BukkitInvContainerItemProvider provider, UUID uuid) {
         this.provider = provider;
         this.uuid = uuid;
-        this.items = Collections.synchronizedList(new ArrayList<>());
+        this.items = Collections.synchronizedList(new ArrayList<InvItemStorage>());
     }
 
     public void addItem(short windowId, short slotId, short anumber) {

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/providers/BukkitInvContainerItemProvider.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/providers/BukkitInvContainerItemProvider.java
@@ -16,6 +16,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.protocol.ProtocolRegistry;
+import us.myles.ViaVersion.api.protocol.ProtocolVersion;
 import us.myles.ViaVersion.bukkit.protocol1_12to1_11_1.BukkitInvContainerUpdateTask;
 import us.myles.ViaVersion.bukkit.util.NMSUtil;
 import us.myles.ViaVersion.protocols.base.ProtocolInfo;
@@ -68,6 +69,9 @@ public class BukkitInvContainerItemProvider extends InvContainerItemProvider {
         }
         InventoryView inv = p.getOpenInventory();
         short slotId = storage.getSlotId();
+        if (slotId < 0) { // clicked out of inv slot
+            return null;
+        }
         if (slotId > inv.countSlots()) {
             return null; // wrong container open?
         }
@@ -85,9 +89,9 @@ public class BukkitInvContainerItemProvider extends InvContainerItemProvider {
             ReflectionUtil.set(cinstance, "d", storage.getActionNumber());
             ReflectionUtil.set(cinstance, "item", nmsItem);
             int protocolId = ProtocolRegistry.SERVER_PROTOCOL;
-            if (protocolId == 47) {
+            if (protocolId == ProtocolVersion.v1_8.getId()) {
                 ReflectionUtil.set(cinstance, "shift", 1);
-            } else if (protocolId >= 107) { // 1.9+
+            } else if (protocolId >= ProtocolVersion.v1_9.getId()) { // 1.9+
                 ReflectionUtil.set(cinstance, "shift", clickTypeEnum);
             }
         } catch (Exception e) {
@@ -128,14 +132,17 @@ public class BukkitInvContainerItemProvider extends InvContainerItemProvider {
         }
         try {
             this.wclickPacketClass = NMSUtil.nms("PacketPlayInWindowClick");
-            Class<?> eclassz = NMSUtil.nms("InventoryClickType");
-            Object[] constants = eclassz.getEnumConstants();
-            this.clickTypeEnum = constants[1]; // QUICK_MOVE
+            int protocolId = ProtocolRegistry.SERVER_PROTOCOL;
+            if (protocolId >= ProtocolVersion.v1_9.getId()) {
+                Class<?> eclassz = NMSUtil.nms("InventoryClickType");
+                Object[] constants = eclassz.getEnumConstants();
+                this.clickTypeEnum = constants[1]; // QUICK_MOVE
+            }
             Class<?> citemStack = NMSUtil.obc("inventory.CraftItemStack");
             this.nmsItemMethod = citemStack.getDeclaredMethod("asNMSCopy", ItemStack.class);
         } catch (Exception e) {
             this.supported = false;
-            return;
+            throw new RuntimeException("Couldn't find required inventory classes", e);
         }
         try {
             this.ephandle = NMSUtil.obc("entity.CraftPlayer").getDeclaredMethod("getHandle");
@@ -159,10 +166,10 @@ public class BukkitInvContainerItemProvider extends InvContainerItemProvider {
 
     private boolean isSupported() {
         int protocolId = ProtocolRegistry.SERVER_PROTOCOL;
-        if (protocolId >= 47 && protocolId <= 316) {
-            return true; // 1.8
+        if (protocolId >= ProtocolVersion.v1_8.getId() && protocolId <= ProtocolVersion.v1_11_1.getId()) {
+            return true; // 1.8-1.11.2
         }
-        // this is not needed on 1.12+
+        // this is not needed on 1.12+ servers
         return false;
     }
 }

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/providers/BukkitInvContainerItemProvider.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/providers/BukkitInvContainerItemProvider.java
@@ -123,7 +123,7 @@ public class BukkitInvContainerItemProvider extends InvContainerItemProvider {
     private void scheduleTask(BukkitInvContainerUpdateTask utask) {
         BukkitScheduler scheduler = Bukkit.getServer().getScheduler();
         Plugin instance = Bukkit.getServer().getPluginManager().getPlugin("ViaVersion");
-        scheduler.runTaskLater(instance, utask, 2); // 2 ticks later (possible double click action).
+        scheduler.runTaskLater(instance, utask, 5); // 5 ticks later (possible double click action).
     }
 
     private void setupReflection() {

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/providers/BukkitInvContainerItemProvider.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/providers/BukkitInvContainerItemProvider.java
@@ -26,7 +26,7 @@ import us.myles.ViaVersion.util.ReflectionUtil;
 
 public class BukkitInvContainerItemProvider extends InvContainerItemProvider {
 
-    private static Map<UUID, BukkitInvContainerUpdateTask> updateTasks = new ConcurrentHashMap<>();
+    private static Map<UUID, BukkitInvContainerUpdateTask> updateTasks = new ConcurrentHashMap<UUID, BukkitInvContainerUpdateTask>();
     private boolean supported;
     // packet class
     private Class<?> wclickPacketClass;

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/tasks/protocol1_12to1_11_1/BukkitInventoryUpdateTask.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/tasks/protocol1_12to1_11_1/BukkitInventoryUpdateTask.java
@@ -1,4 +1,4 @@
-package us.myles.ViaVersion.bukkit.protocol1_12to1_11_1;
+package us.myles.ViaVersion.bukkit.tasks.protocol1_12to1_11_1;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -8,23 +8,23 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
-import us.myles.ViaVersion.bukkit.providers.BukkitInvContainerItemProvider;
-import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.storage.InvItemStorage;
+import us.myles.ViaVersion.bukkit.providers.BukkitInventoryQuickMoveProvider;
+import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.storage.ItemTransaction;
 
-public class BukkitInvContainerUpdateTask implements Runnable {
+public class BukkitInventoryUpdateTask implements Runnable {
 
-    private BukkitInvContainerItemProvider provider;
+    private BukkitInventoryQuickMoveProvider provider;
     private final UUID uuid;
-    private final List<InvItemStorage> items;
+    private final List<ItemTransaction> items;
 
-    public BukkitInvContainerUpdateTask(BukkitInvContainerItemProvider provider, UUID uuid) {
+    public BukkitInventoryUpdateTask(BukkitInventoryQuickMoveProvider provider, UUID uuid) {
         this.provider = provider;
         this.uuid = uuid;
-        this.items = Collections.synchronizedList(new ArrayList<InvItemStorage>());
+        this.items = Collections.synchronizedList(new ArrayList<ItemTransaction>());
     }
 
-    public void addItem(short windowId, short slotId, short anumber) {
-        InvItemStorage storage = new InvItemStorage(windowId, slotId, anumber);
+    public void addItem(short windowId, short slotId, short actionId) {
+        ItemTransaction storage = new ItemTransaction(windowId, slotId, actionId);
         items.add(storage);
     }
 
@@ -37,7 +37,7 @@ public class BukkitInvContainerUpdateTask implements Runnable {
         }
         try {
             synchronized (items) {
-                for (InvItemStorage storage : items) {
+                for (ItemTransaction storage : items) {
                     Object packet = provider.buildWindowClickPacket(p, storage);
                     boolean result = provider.sendPlayer(p, packet);
                     if (!result) {

--- a/bungee/src/main/java/us/myles/ViaVersion/BungeePlugin.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/BungeePlugin.java
@@ -80,6 +80,11 @@ public class BungeePlugin extends Plugin implements ViaPlatform, Listener {
     }
 
     @Override
+    public TaskId runSync(Runnable runnable, Long ticks) {
+        return new BungeeTaskId(getProxy().getScheduler().schedule(this, runnable, ticks * 50, TimeUnit.MILLISECONDS).getId());
+    }
+
+    @Override
     public TaskId runRepeatingSync(Runnable runnable, Long ticks) {
         return new BungeeTaskId(getProxy().getScheduler().schedule(this, runnable, 0, ticks * 50, TimeUnit.MILLISECONDS).getId());
     }

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeConfigAPI.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeConfigAPI.java
@@ -10,7 +10,7 @@ import java.net.URL;
 import java.util.*;
 
 public class BungeeConfigAPI extends Config implements ViaVersionConfig {
-    private static List<String> UNSUPPORTED = Arrays.asList("nms-player-ticking", "item-cache", "anti-xray-patch");
+    private static List<String> UNSUPPORTED = Arrays.asList("nms-player-ticking", "item-cache", "anti-xray-patch", "quick-move-action-fix");
 
     public BungeeConfigAPI(File configFile) {
         super(new File(configFile, "config.yml"));
@@ -202,6 +202,11 @@ public class BungeeConfigAPI extends Config implements ViaVersionConfig {
     @Override
     public boolean is1_12NBTArrayFix() {
         return getBoolean("chat-nbt-fix", true);
+    }
+    
+    @Override
+    public boolean is1_12QuickMoveActionFix() {
+        return false;
     }
 
     @Override

--- a/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
@@ -209,7 +209,14 @@ public interface ViaVersionConfig {
      * @return True if enabled
      */
     boolean is1_12NBTArrayFix();
-
+    
+    /**
+     * Should we fix shift quick move action for 1.12 clients
+     *
+     * @return True if enabled
+     */
+    boolean is1_12QuickMoveActionFix();
+    
     /**
      * Get the blocked protocols
      *

--- a/common/src/main/java/us/myles/ViaVersion/api/platform/ViaPlatform.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/platform/ViaPlatform.java
@@ -60,6 +60,16 @@ public interface ViaPlatform<T> {
     TaskId runSync(Runnable runnable);
 
     /**
+     * Run a task Sync after a interval
+     * This must be only used after plugin enable.
+     *
+     * @param runnable The task to run
+     * @param ticks    The interval to run it after
+     * @return The Task ID
+     */
+    TaskId runSync(Runnable runnable, Long ticks);
+
+    /**
      * Run a task at a repeating interval.
      * Initial interval is the same as repeat.
      *

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/Protocol1_12To1_11_1.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/Protocol1_12To1_11_1.java
@@ -20,7 +20,7 @@ import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.api.type.types.version.Types1_12;
 import us.myles.ViaVersion.packets.State;
 import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.packets.InventoryPackets;
-import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.providers.InvContainerItemProvider;
+import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.providers.InventoryQuickMoveProvider;
 import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.storage.EntityTracker;
 import us.myles.ViaVersion.protocols.protocol1_9_1_2to1_9_3_4.types.Chunk1_9_3_4Type;
 import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
@@ -389,7 +389,7 @@ public class Protocol1_12To1_11_1 extends Protocol {
     
     @Override
     protected void register(ViaProviders providers) {
-        providers.register(InvContainerItemProvider.class, new InvContainerItemProvider());
+        providers.register(InventoryQuickMoveProvider.class, new InventoryQuickMoveProvider());
     }
 
     @Override

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
@@ -120,9 +120,13 @@ public class InventoryPackets {
                         handler(new PacketHandler() {
                             @Override
                             public void handle(PacketWrapper wrapper) throws Exception {
+                                Item item = wrapper.get(Type.ITEM, 0);
+                                if (!Via.getConfig().is1_12QuickMoveActionFix()) {
+                                    BedRewriter.toServerItem(item);
+                                    return;
+                                }
                                 byte button = wrapper.get(Type.BYTE, 0);
                                 int mode = wrapper.get(Type.VAR_INT, 0);
-                                Item item = wrapper.get(Type.ITEM, 0);
                                 // QUICK_MOVE PATCH (Shift + (click/double click))
                                 if (mode == 1 && button == 0 && item == null) { 
                                     short windowId = wrapper.get(Type.UNSIGNED_BYTE, 0);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/packets/InventoryPackets.java
@@ -9,7 +9,7 @@ import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.packets.State;
 import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.BedRewriter;
 import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.Protocol1_12To1_11_1;
-import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.providers.InvContainerItemProvider;
+import us.myles.ViaVersion.protocols.protocol1_12to1_11_1.providers.InventoryQuickMoveProvider;
 
 public class InventoryPackets {
     public static void register(Protocol1_12To1_11_1 protocol) {
@@ -128,12 +128,12 @@ public class InventoryPackets {
                                 byte button = wrapper.get(Type.BYTE, 0);
                                 int mode = wrapper.get(Type.VAR_INT, 0);
                                 // QUICK_MOVE PATCH (Shift + (click/double click))
-                                if (mode == 1 && button == 0 && item == null) { 
+                                if (mode == 1 && button == 0 && item == null) {
                                     short windowId = wrapper.get(Type.UNSIGNED_BYTE, 0);
                                     short slotId = wrapper.get(Type.SHORT, 0);
-                                    short anumber = wrapper.get(Type.SHORT, 1);
-                                    InvContainerItemProvider provider = Via.getManager().getProviders().get(InvContainerItemProvider.class);
-                                    boolean succeed = provider.registerInvClickPacket(windowId, slotId, anumber, wrapper.user());
+                                    short actionId = wrapper.get(Type.SHORT, 1);
+                                    InventoryQuickMoveProvider provider = Via.getManager().getProviders().get(InventoryQuickMoveProvider.class);
+                                    boolean succeed = provider.registerQuickMove(windowId, slotId, actionId, wrapper.user());
                                     if (succeed) {
                                         wrapper.cancel();
                                     }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/providers/InventoryQuickMoveProvider.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/providers/InventoryQuickMoveProvider.java
@@ -3,9 +3,9 @@ package us.myles.ViaVersion.protocols.protocol1_12to1_11_1.providers;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.platform.providers.Provider;
 
-public class InvContainerItemProvider implements Provider {
+public class InventoryQuickMoveProvider implements Provider {
 
-    public boolean registerInvClickPacket(short windowId, short slotId, short anumber, UserConnection uconnection) {
+    public boolean registerQuickMove(short windowId, short slotId, short actionId, UserConnection userConnection) {
         return false; // not supported :/ plays very sad violin
     }
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/storage/ItemTransaction.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_12to1_11_1/storage/ItemTransaction.java
@@ -7,9 +7,8 @@ import lombok.ToString;
 @AllArgsConstructor
 @ToString
 @Getter
-public class InvItemStorage {
-
+public class ItemTransaction {
     private short windowId;
     private short slotId;
-    private short actionNumber;
+    private short actionId;
 }

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -84,6 +84,8 @@ hologram-y: -0.96
 piston-animation-patch: false
 # Should we fix nbt for 1.12 and above clients in chat messages (causes invalid item)
 chat-nbt-fix: true
+# Should we fix shift quick move action for 1.12 clients (causes shift + double click not to work when moving items) (only works on 1.8-1.11.2 bukkit based servers)
+quick-move-action-fix: true
 #
 #----------------------------------------------------------#
 #         1.9 & 1.10 CLIENTS ON 1.8 SERVERS OPTIONS        #

--- a/sponge/src/main/java/us/myles/ViaVersion/SpongePlugin.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/SpongePlugin.java
@@ -3,7 +3,6 @@ package us.myles.ViaVersion;
 import com.google.gson.JsonObject;
 import com.google.inject.Inject;
 import org.spongepowered.api.Game;
-import org.spongepowered.api.Sponge;
 import org.spongepowered.api.config.DefaultConfig;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.Listener;
@@ -111,6 +110,12 @@ public class SpongePlugin implements ViaPlatform {
     public TaskId runSync(Runnable runnable) {
         syncExecutor.execute(runnable);
         return new SpongeTaskId(null);
+    }
+
+    @Override
+    public TaskId runSync(Runnable runnable, Long ticks) {
+        Long delay = ticks * 50L;
+        return new SpongeTaskId(syncExecutor.schedule(runnable, delay, TimeUnit.MILLISECONDS).getTask());
     }
 
     @Override

--- a/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeConfigAPI.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeConfigAPI.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class SpongeConfigAPI extends Config implements ViaVersionConfig {
-    private static List<String> UNSUPPORTED = Arrays.asList("anti-xray-patch", "bungee-ping-interval", "bungee-ping-save", "bungee-servers");
+    private static List<String> UNSUPPORTED = Arrays.asList("anti-xray-patch", "bungee-ping-interval", "bungee-ping-save", "bungee-servers", "quick-move-action-fix");
     private final PluginContainer pluginContainer;
 
     public SpongeConfigAPI(PluginContainer pluginContainer, File configFile) {
@@ -184,6 +184,11 @@ public class SpongeConfigAPI extends Config implements ViaVersionConfig {
     @Override
     public boolean is1_12NBTArrayFix() {
         return getBoolean("chat-nbt-fix", true);
+    }
+    
+    @Override
+    public boolean is1_12QuickMoveActionFix() {
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This improves inventory handling and fixes #739 for **bukkit** servers.
1.12+ clients behave differently with the WindowClick packet when used with quick move action. 
http://wiki.vg/index.php?title=Protocol&oldid=13223#Click_Window

Previously clients grab the item from the clicked slot **before** it has been moved however now they grab the slot item **after** it has been moved and send that in the packet. 
Because of this the slot will always be empty so the sent item is null which doesn't make any sense.  
< 1.12 servers require the client to send the moved item and then the server will compare it to see if it equals with the item that the server has (to prevent abuse or something?). 
This isn't the case on 1.12+ servers due they no longer require the item being sent in the packet. So in order to patch this we need to make the server think we sent the right item.

At first i didn't want to use scheduler but later on i figured that it'd be the best option because at the end the action will be executed on the main thread anyway. Also waiting a few ticks before sending it to the server we're able to send all the items at once from one runnable rather than creating multiple runnables.