### PR TITLE
Skulls don't have 'Rot'; Painting names

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocolsnapshotto1_12_2/providers/PaintingProvider.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocolsnapshotto1_12_2/providers/PaintingProvider.java
@@ -28,14 +28,14 @@ public class PaintingProvider implements Provider {
         add("bust");
         add("stage");
         add("void");
-        add("skull_and_roses");
+        add("skullandroses");
         add("wither");
         add("fighters");
         add("pointer");
         add("pigscene");
-        add("burning_skull");
+        add("burningskull");
         add("skeleton");
-        add("donkey_kong");
+        add("donkeykong");
     }
 
     private void add(String motive) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocolsnapshotto1_12_2/providers/blockentities/SkullHandler.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocolsnapshotto1_12_2/providers/blockentities/SkullHandler.java
@@ -23,7 +23,10 @@ public class SkullHandler implements BlockEntityProvider.BlockEntityHandler {
         int id = storage.get(position).getOriginal();
 
         if (id >= SKULL_WALL_START && id <= SKULL_END) {
-            id += (byte) tag.get("SkullType").getValue() * 20 + (byte) tag.get("Rot").getValue();
+            id += (byte) tag.get("SkullType").getValue() * 20;
+            if (tag.contains("Rot")) {
+                id += (byte) tag.get("Rot").getValue();
+            }
         } else {
             System.out.println("Why does this block have the skull block entity? :(" + tag);
             return -1;


### PR DESCRIPTION
Skulls on walls don't always have a 'Rot' tag if it's rotation is 0.
'DonkeyKong', 'SkullAndRoses' and 'BurningSkull' were displaying the default painting instead.