### PR TITLE
Don't use Paper block placement patch in 1.12.

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaLoader.java
@@ -11,6 +11,8 @@ import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.platform.ViaPlatformLoader;
+import us.myles.ViaVersion.api.protocol.ProtocolRegistry;
+import us.myles.ViaVersion.api.protocol.ProtocolVersion;
 import us.myles.ViaVersion.bukkit.listeners.UpdateListener;
 import us.myles.ViaVersion.bukkit.listeners.protocol1_9to1_8.*;
 import us.myles.ViaVersion.bukkit.providers.BukkitInventoryQuickMoveProvider;
@@ -68,10 +70,11 @@ public class BukkitViaLoader implements ViaPlatformLoader {
         storeListener(new DeathListener(plugin)).register();
         storeListener(new BlockListener(plugin)).register();
 
-        if (Bukkit.getVersion().toLowerCase().contains("paper")
+        if ((Bukkit.getVersion().toLowerCase().contains("paper")
                 || Bukkit.getVersion().toLowerCase().contains("taco")
-                || Bukkit.getVersion().toLowerCase().contains("torch")) {
-            plugin.getLogger().info("Enabling PaperSpigot/TacoSpigot/Torch patch: Fixes block placement.");
+                || Bukkit.getVersion().toLowerCase().contains("torch"))
+				&& ProtocolRegistry.SERVER_PROTOCOL < ProtocolVersion.v1_12.getId()) {
+            plugin.getLogger().info("Enabling Paper/TacoSpigot/Torch patch: Fixes block placement.");
             storeListener(new PaperPatch(plugin)).register();
         }
         if (plugin.getConf().isItemCache()) {


### PR DESCRIPTION
Apparently the bug that caused the block placement issues with Paper was fixed in 1.12 ([according to Aikar from its development team](https://vgy.me/r4Xyal.png)). So, with this ~~commit~~ PR the patch to fix it won't run if the server is running Paper 1.12 or higher (which means it will only be used in 1.11.2 and lower server versions).