### PR TITLE
Fix italic item names

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -305,9 +305,13 @@ public class InventoryPackets {
                 if (((CompoundTag) tag.get("display")).get("Name") instanceof StringTag) {
                     StringTag name = ((CompoundTag) tag.get("display")).get("Name");
                     BaseComponent[] components = TextComponent.fromLegacyText(name.getValue());
-                    TextComponent root = new TextComponent(components);
-                    root.setItalic(false);
-                    name.setValue(ComponentSerializer.toString(root));
+                    if (name.getValue().startsWith("§")) {
+                        TextComponent root = new TextComponent(components);
+                        root.setItalic(false);
+                        name.setValue(ComponentSerializer.toString(root));
+                    } else {
+                        name.setValue(ComponentSerializer.toString(components));
+                    }
                 }
             }
             // ench is now Enchantments and now uses identifiers

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -4,6 +4,9 @@ import com.github.steveice10.opennbt.tag.builtin.*;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.io.BaseEncoding;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.protocol.Protocol;
@@ -301,11 +304,10 @@ public class InventoryPackets {
             if (tag.get("display") instanceof CompoundTag) {
                 if (((CompoundTag) tag.get("display")).get("Name") instanceof StringTag) {
                     StringTag name = ((CompoundTag) tag.get("display")).get("Name");
-                    name.setValue(
-                            Protocol1_13To1_12_2.legacyTextToJson(
-                                    name.getValue()
-                            )
-                    );
+                    BaseComponent[] components = TextComponent.fromLegacyText(name.getValue());
+                    TextComponent root = new TextComponent(components);
+                    root.setItalic(false);
+                    name.setValue(ComponentSerializer.toString(root));
                 }
             }
             // ench is now Enchantments and now uses identifiers


### PR DESCRIPTION
Fixes https://github.com/MylesIsCool/ViaVersion/issues/888

I tested this fix with the items given by the following commands:
``give @p minecraft:stone 1 0 {display:{Name:"§4§otest"}}``
``give @p minecraft:stone 1 0 {display:{Name:"§4§otest2"}}``
``give @p minecraft:stone 1 0 {display:{Name:"§o§4test3"}}``
``give @p minecraft:stone 1 0 {display:{Name:"§4test§c§o4"}}``
All of them look the same for 1.13 and 1.12.2 clients :)