### PR TITLE
Fix rewriting of MC|StopSound plugin channel.

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -84,7 +84,7 @@ public class InventoryPackets {
 
                             // Reset the packet
                             wrapper.clearPacket();
-                            wrapper.setId(0x4B);
+                            wrapper.setId(0x4C);
 
                             byte flags = 0;
                             wrapper.write(Type.BYTE, flags); // Placeholder


### PR DESCRIPTION
Fixes 1.13 clients disconnecting when Mc|StopSound is sent by server.
![image](https://user-images.githubusercontent.com/4339870/43037289-a259c0e2-8d0c-11e8-9364-8d41a943f239.png)
Json parsing exception is thrown because client tries to read TextComponent which is present in PacketPlayOutTitle(0x4B)