### PR TITLE
Add support for Snapshot 18w30a and 18w30b

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# ViaVersion 1.3.0 - Spigot, Sponge, BungeeCord
+# ViaVersion 1.4.0 - Spigot, Sponge, BungeeCord
 [![Build Status](https://travis-ci.org/MylesIsCool/ViaVersion.svg?branch=master)](https://travis-ci.org/MylesIsCool/ViaVersion)
-[![Gitter](https://badges.gitter.im/MylesIsCool/ViaVersion.svg)](https://gitter.im/MylesIsCool/ViaVersion)
 [![Discord](https://img.shields.io/badge/chat-on%20discord-blue.svg)](https://viaversion.com/discord)
 
 IRC: [#viaversion](http://irc.spi.gt/iris/?channels=viaversion) on irc.spi.gt for Support.
@@ -9,7 +8,7 @@ IRC: [#viaversion](http://irc.spi.gt/iris/?channels=viaversion) on irc.spi.gt fo
 
 Supported Versions:
 
-![Table (http://i.imgur.com/jbrm2Ep.png)](http://i.imgur.com/jbrm2Ep.png)
+![Table (https://i.imgur.com/YZNJhUv.png)](https://i.imgur.com/YZNJhUv.png)
 
 On Bukkit you may also use ProtocolSupport, but ensure you have the right build for your server version.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ViaVersion 1.4.0 - Spigot, Sponge, BungeeCord
+# ViaVersion 1.4.1 - Spigot, Sponge, BungeeCord
 [![Build Status](https://travis-ci.org/MylesIsCool/ViaVersion.svg?branch=master)](https://travis-ci.org/MylesIsCool/ViaVersion)
 [![Discord](https://img.shields.io/badge/chat-on%20discord-blue.svg)](https://viaversion.com/discord)
 

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0-DEV</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0</version>
+        <version>1.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bukkit/pom.xml
+++ b/bukkit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitConfigAPI.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitConfigAPI.java
@@ -199,4 +199,9 @@ public class BukkitConfigAPI extends Config implements ViaVersionConfig {
     public List<String> getUnsupportedOptions() {
         return UNSUPPORTED;
     }
+
+    @Override
+    public boolean is1_13TeamColourFix() {
+        return getBoolean("team-colour-fix", true);
+    }
 }

--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaLoader.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaLoader.java
@@ -11,6 +11,8 @@ import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.minecraft.item.Item;
 import us.myles.ViaVersion.api.platform.ViaPlatformLoader;
+import us.myles.ViaVersion.api.protocol.ProtocolRegistry;
+import us.myles.ViaVersion.api.protocol.ProtocolVersion;
 import us.myles.ViaVersion.bukkit.listeners.UpdateListener;
 import us.myles.ViaVersion.bukkit.listeners.protocol1_9to1_8.*;
 import us.myles.ViaVersion.bukkit.providers.BukkitInventoryQuickMoveProvider;
@@ -68,10 +70,11 @@ public class BukkitViaLoader implements ViaPlatformLoader {
         storeListener(new DeathListener(plugin)).register();
         storeListener(new BlockListener(plugin)).register();
 
-        if (Bukkit.getVersion().toLowerCase().contains("paper")
+        if ((Bukkit.getVersion().toLowerCase().contains("paper")
                 || Bukkit.getVersion().toLowerCase().contains("taco")
-                || Bukkit.getVersion().toLowerCase().contains("torch")) {
-            plugin.getLogger().info("Enabling PaperSpigot/TacoSpigot/Torch patch: Fixes block placement.");
+                || Bukkit.getVersion().toLowerCase().contains("torch"))
+				&& ProtocolRegistry.SERVER_PROTOCOL < ProtocolVersion.v1_12.getId()) {
+            plugin.getLogger().info("Enabling Paper/TacoSpigot/Torch patch: Fixes block placement.");
             storeListener(new PaperPatch(plugin)).register();
         }
         if (plugin.getConf().isItemCache()) {

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0-DEV</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0</version>
+        <version>1.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bungee/pom.xml
+++ b/bungee/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeConfigAPI.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeConfigAPI.java
@@ -252,4 +252,9 @@ public class BungeeConfigAPI extends Config implements ViaVersionConfig {
     public Map<String, Integer> getBungeeServerProtocols() {
         return get("bungee-servers", Map.class, new HashMap<>());
     }
+
+    @Override
+    public boolean is1_13TeamColourFix() {
+        return getBoolean("team-colour-fix", true);
+    }
 }

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -11,6 +11,18 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>viaversion-common</artifactId>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
         <!-- Snake YAML -->
         <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0-DEV</version>
+        <version>1.4.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -11,18 +11,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>viaversion-common</artifactId>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <dependencies>
         <!-- Snake YAML -->
         <dependency>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0</version>
+        <version>1.4.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
@@ -209,6 +209,13 @@ public interface ViaVersionConfig {
      * @return True if enabled
      */
     boolean is1_12NBTArrayFix();
+
+    /**
+     * Should we make team colours based on the last colour in team prefix
+     *
+     * @return True if enabled
+     */
+    boolean is1_13TeamColourFix();
     
     /**
      * Should we fix shift quick move action for 1.12 clients

--- a/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolRegistry.java
@@ -19,6 +19,7 @@ import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.Protocol1_9_3TO1_9_1
 import us.myles.ViaVersion.protocols.protocol1_9to1_8.Protocol1_9TO1_8;
 import us.myles.ViaVersion.protocols.protocol1_9to1_9_1.Protocol1_9TO1_9_1;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.Protocol1_13To1_12_2;
+import us.myles.ViaVersion.protocols.snapshot.protocol18w30ato1_13.Protocol18w30aTO1_13;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -56,6 +57,7 @@ public class ProtocolRegistry {
 
         // 1.13 support in development! (:
         registerProtocol(new Protocol1_13To1_12_2(), Collections.singletonList(ProtocolVersion.v1_13.getId()), ProtocolVersion.v1_12_2.getId());
+        registerProtocol(new Protocol18w30aTO1_13(),  Arrays.asList(ProtocolVersion.v18w30a.getId(), ProtocolVersion.v18w30b.getId()), ProtocolVersion.v1_13.getId());
     }
 
     /**

--- a/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolVersion.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/protocol/ProtocolVersion.java
@@ -34,6 +34,8 @@ public class ProtocolVersion {
     public static final ProtocolVersion v1_12_2;
     // v1_13 as name for better ViaBackwards compatibility.
     public static final ProtocolVersion v1_13;
+    public static final ProtocolVersion v18w30a;
+    public static final ProtocolVersion v18w30b;
     public static final ProtocolVersion unknown;
 
     private final int id;
@@ -63,6 +65,8 @@ public class ProtocolVersion {
         register(v1_12_1 = new ProtocolVersion(338, "1.12.1"));
         register(v1_12_2 = new ProtocolVersion(340, "1.12.2"));
         register(v1_13 = new ProtocolVersion(393, "1.13"));
+        register(v18w30a = new ProtocolVersion(394, "18w30a"));
+        register(v18w30b = new ProtocolVersion(395, "18w30b"));
         register(unknown = new ProtocolVersion(-1, "UNKNOWN"));
     }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/ChatRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/ChatRewriter.java
@@ -1,0 +1,118 @@
+package us.myles.ViaVersion.protocols.protocol1_13to1_12_2;
+
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.chat.ComponentSerializer;
+
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ChatRewriter {
+    // Based on https://github.com/SpigotMC/BungeeCord/blob/master/chat/src/main/java/net/md_5/bungee/api/chat/TextComponent.java
+
+    private static final Pattern url = Pattern.compile("^(?:(https?)://)?([-\\w_\\.]{2,}\\.[a-z]{2,4})(/\\S*)?$");
+
+    public static BaseComponent[] fromLegacyText(String message, ChatColor defaultColor) {
+        ArrayList<BaseComponent> components = new ArrayList<>();
+        StringBuilder builder = new StringBuilder();
+        TextComponent component = new TextComponent();
+        Matcher matcher = url.matcher(message);
+
+        for (int i = 0; i < message.length(); i++) {
+            char c = message.charAt(i);
+            if (c == ChatColor.COLOR_CHAR) {
+                if (++i >= message.length()) {
+                    break;
+                }
+                c = message.charAt(i);
+                if (c >= 'A' && c <= 'Z') {
+                    c += 32;
+                }
+                ChatColor format = ChatColor.getByChar(c);
+                if (format == null) {
+                    continue;
+                }
+                if (builder.length() > 0) {
+                    TextComponent old = component;
+                    component = new TextComponent(old);
+                    old.setText(builder.toString());
+                    builder = new StringBuilder();
+                    components.add(old);
+                }
+                switch (format) {
+                    case BOLD:
+                        component.setBold(true);
+                        break;
+                    case ITALIC:
+                        component.setItalic(true);
+                        break;
+                    case UNDERLINE:
+                        component.setUnderlined(true);
+                        break;
+                    case STRIKETHROUGH:
+                        component.setStrikethrough(true);
+                        break;
+                    case MAGIC:
+                        component.setObfuscated(true);
+                        break;
+                    case RESET:
+                        format = defaultColor;
+                    default:
+                        component = new TextComponent();
+                        component.setColor(format);
+                        // ViaVersion start
+                        component.setBold(false);
+                        component.setItalic(false);
+                        component.setUnderlined(false);
+                        component.setStrikethrough(false);
+                        component.setObfuscated(false);
+                        // ViaVersion end
+                        break;
+                }
+                continue;
+            }
+            int pos = message.indexOf(' ', i);
+            if (pos == -1) {
+                pos = message.length();
+            }
+            if (matcher.region(i, pos).find()) { //Web link handling
+
+                if (builder.length() > 0) {
+                    TextComponent old = component;
+                    component = new TextComponent(old);
+                    old.setText(builder.toString());
+                    builder = new StringBuilder();
+                    components.add(old);
+                }
+
+                TextComponent old = component;
+                component = new TextComponent(old);
+                String urlString = message.substring(i, pos);
+                component.setText(urlString);
+                component.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL,
+                        urlString.startsWith("http") ? urlString : "http://" + urlString));
+                components.add(component);
+                i += pos - i - 1;
+                component = old;
+                continue;
+            }
+            builder.append(c);
+        }
+
+        component.setText(builder.toString());
+        components.add(component);
+
+        return components.toArray(new BaseComponent[0]);
+    }
+
+    public static String legacyTextToJson(String legacyText) {
+        return ComponentSerializer.toString(fromLegacyText(legacyText, ChatColor.WHITE));
+    }
+
+    public static String jsonTextToLegacy(String value) {
+        return TextComponent.toLegacyText(ComponentSerializer.parse(value));
+    }
+}

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
@@ -1,5 +1,7 @@
 package us.myles.ViaVersion.protocols.protocol1_13to1_12_2;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.md_5.bungee.chat.ComponentSerializer;
@@ -17,7 +19,6 @@ import us.myles.ViaVersion.api.remapper.ValueCreator;
 import us.myles.ViaVersion.api.remapper.ValueTransformer;
 import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.packets.State;
-import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data.MappingData;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.packets.EntityPackets;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.packets.InventoryPackets;
@@ -28,6 +29,8 @@ import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.storage.BlockStorage;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.storage.EntityTracker;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.storage.TabCompleteTracker;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.types.Particle1_13Type;
+import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
+import us.myles.ViaVersion.util.GsonUtil;
 
 import java.util.Map;
 
@@ -117,6 +120,28 @@ public class Protocol1_13To1_12_2 extends Protocol {
         InventoryPackets.register(this);
 
         // Outgoing packets
+
+        registerOutgoing(State.STATUS, 0x00, 0x00, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.STRING);
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        String response = wrapper.get(Type.STRING, 0);
+                        try {
+                            JsonObject json = GsonUtil.getGson().fromJson(response, JsonObject.class);
+                            if (json.has("favicon")) {
+                                json.addProperty("favicon", json.get("favicon").getAsString().replace("\n", ""));
+                            }
+                            wrapper.set(Type.STRING, 0, GsonUtil.getGson().toJson(json));
+                        } catch (JsonParseException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                });
+            }
+        });
 
         // New packet 0x04 - Login Plugin Message
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
@@ -38,12 +38,6 @@ import java.util.Map;
 public class Protocol1_13To1_12_2 extends Protocol {
     public static final Particle1_13Type PARTICLE_TYPE = new Particle1_13Type();
 
-    public static String legacyTextToJson(String legacyText) {
-        return ComponentSerializer.toString(
-                TextComponent.fromLegacyText(legacyText)
-        );
-    }
-
     public static final PacketHandler POS_TO_3_INT = new PacketHandler() {
         @Override
         public void handle(PacketWrapper wrapper) throws Exception {
@@ -106,10 +100,6 @@ public class Protocol1_13To1_12_2 extends Protocol {
 
     static {
         MappingData.init();
-    }
-
-    public static String jsonTextToLegacy(String value) {
-        return TextComponent.toLegacyText(ComponentSerializer.parse(value));
     }
 
     @Override
@@ -358,7 +348,7 @@ public class Protocol1_13To1_12_2 extends Protocol {
                         // On create or update
                         if (mode == 0 || mode == 2) {
                             String value = wrapper.read(Type.STRING); // Value
-                            value = legacyTextToJson(value);
+                            value = ChatRewriter.legacyTextToJson(value);
                             wrapper.write(Type.STRING, value);
 
                             String type = wrapper.read(Type.STRING);
@@ -385,7 +375,7 @@ public class Protocol1_13To1_12_2 extends Protocol {
 
                         if (action == 0 || action == 2) {
                             String displayName = wrapper.read(Type.STRING); // Display Name
-                            displayName = legacyTextToJson(displayName);
+                            displayName = ChatRewriter.legacyTextToJson(displayName);
                             wrapper.write(Type.STRING, displayName);
 
                             String prefix = wrapper.read(Type.STRING); // Prefix moved
@@ -408,8 +398,8 @@ public class Protocol1_13To1_12_2 extends Protocol {
 
                             wrapper.write(Type.VAR_INT, colour);
 
-                            wrapper.write(Type.STRING, legacyTextToJson(prefix)); // Prefix
-                            wrapper.write(Type.STRING, legacyTextToJson(suffix)); // Suffix
+                            wrapper.write(Type.STRING, ChatRewriter.legacyTextToJson(prefix)); // Prefix
+                            wrapper.write(Type.STRING, ChatRewriter.legacyTextToJson(suffix)); // Suffix
                         }
                     }
                 });

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/Protocol1_13To1_12_2.java
@@ -3,8 +3,6 @@ package us.myles.ViaVersion.protocols.protocol1_13to1_12_2;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.TextComponent;
-import net.md_5.bungee.chat.ComponentSerializer;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
@@ -437,8 +435,36 @@ public class Protocol1_13To1_12_2 extends Protocol {
                 handler(new PacketHandler() {
                     @Override
                     public void handle(PacketWrapper wrapper) throws Exception {
-                        // TODO Temporary cancel advancements because of 'Non [a-z0-9/._-] character in path of location: minecraft:? https://fs.matsv.nl/media?id=auwje4z4lxw.png
-                        wrapper.cancel();
+                        wrapper.passthrough(Type.BOOLEAN); // Reset/clear
+                        int size = wrapper.passthrough(Type.VAR_INT); // Mapping size
+
+                        for (int i = 0; i < size; i++) {
+                            wrapper.passthrough(Type.STRING); // Identifier
+
+                            // Parent
+                            if (wrapper.passthrough(Type.BOOLEAN))
+                                wrapper.passthrough(Type.STRING);
+
+                            // Display data
+                            if (wrapper.passthrough(Type.BOOLEAN)) {
+                                wrapper.passthrough(Type.STRING); // Title
+                                wrapper.passthrough(Type.STRING); // Description
+                                wrapper.write(Type.FLAT_ITEM, wrapper.read(Type.ITEM)); // Translate item to flat item
+                                wrapper.passthrough(Type.VAR_INT); // Frame type
+                                int flags = wrapper.passthrough(Type.INT); // Flags
+                                if ((flags & 1) != 0)
+                                    wrapper.passthrough(Type.STRING); // Background texture
+                                wrapper.passthrough(Type.FLOAT); // X
+                                wrapper.passthrough(Type.FLOAT); // Y
+                            }
+
+                            wrapper.passthrough(Type.STRING_ARRAY); // Criteria
+
+                            int arrayLength = wrapper.passthrough(Type.VAR_INT);
+                            for (int array = 0; array < arrayLength; array++) {
+                                wrapper.passthrough(Type.STRING_ARRAY); // String array
+                            }
+                        }
                     }
                 });
             }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/chunks/ChunkSection1_13.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/chunks/ChunkSection1_13.java
@@ -135,7 +135,12 @@ public class ChunkSection1_13 implements ChunkSection {
         }
 
         // Read blocks
-        Long[] blockData = Type.LONG_ARRAY.read(input);
+        // Long[] blockData = Type.LONG_ARRAY.read(input);
+        long[] blockData = new long[Type.VAR_INT.read(input)];
+        for (int i = 0; i < blockData.length; i++) {
+            blockData[i] = input.readLong();
+        }
+
         if (blockData.length > 0) {
             for (int i = 0; i < blocks.length; i++) {
                 int bitIndex = i * bitsPerBlock;
@@ -222,7 +227,7 @@ public class ChunkSection1_13 implements ChunkSection {
             }
         }
         for (long l : data) {
-            Type.LONG.write(output, l);
+            output.writeLong(l);
         }
     }
 
@@ -265,7 +270,7 @@ public class ChunkSection1_13 implements ChunkSection {
             }
         }
         for (long l : data) {
-            Type.LONG.write(output, l);
+            output.writeLong(l);
         }
     }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/EntityNameRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/EntityNameRewriter.java
@@ -1,0 +1,56 @@
+package us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/*
+    CHANGED ENTITY NAMES IN 1.13
+
+    commandblock_minecart => command_block_minecart
+    ender_crystal => end_crystal
+    evocation_fangs => evoker_fangs
+    evocation_illager => evoker
+    eye_of_ender_signal => eye_of_ender
+    fireworks_rocket => firework_rocket
+    illusion_illager => illusioner
+    snowman => snow_golem
+    villager_golem => iron_golem
+    vindication_illager => vindicator
+    xp_bottle => experience_bottle
+    xp_orb => experience_orb
+ */
+public class EntityNameRewriter {
+    private static Map<String, String> entityNames = new ConcurrentHashMap<>();
+
+    static {
+        /*
+            CHANGED NAMES IN 1.13
+         */
+        reg("commandblock_minecart", "command_block_minecart");
+        reg("ender_crystal", "end_crystal");
+        reg("evocation_fangs", "evoker_fangs");
+        reg("evocation_illager", "evoker");
+        reg("eye_of_ender_signal", "eye_of_ender");
+        reg("fireworks_rocket", "firework_rocket");
+        reg("illusion_illager", "illusioner");
+        reg("snowman", "snow_golem");
+        reg("villager_golem", "iron_golem");
+        reg("vindication_illager", "vindicator");
+        reg("xp_bottle", "experience_bottle");
+        reg("xp_orb", "experience_orb");
+    }
+
+
+    private static void reg(String past, String future) {
+        entityNames.put("minecraft:" + past, "minecraft:" + future);
+    }
+
+    public static String rewrite(String entName) {
+        if (entityNames.containsKey(entName))
+            return entityNames.get(entName);
+        if (entityNames.containsKey("minecraft:" + entName))
+            return entityNames.get("minecraft:" + entName);
+        else
+            return entName;
+    }
+}

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/ParticleRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/ParticleRewriter.java
@@ -61,7 +61,7 @@ public class ParticleRewriter {
         // Item	Slot	The item that will be used.
         add(3, blockHandler()); // (37->3) blockcrack_(id+(data<<12))   -> minecraft:block
         // BlockState	VarInt	The ID of the block state.
-        add(3, blockWithoutMetaHandler()); // (38->3) blockdust_(id)               -> minecraft:block
+        add(3, blockHandler()); // (38->3) blockdust_(id)               -> minecraft:block
         // BlockState	VarInt	The ID of the block state.
         add(36); // (39->36) droplet -> minecraft:rain
         add(-1); // (40->-1) take -> REMOVED (TODO REPLACENT/CLIENT_SIDED?)
@@ -70,7 +70,7 @@ public class ParticleRewriter {
         add(16); // (43->16) endrod -> minecraft:end_rod
         add(7); // (44->7) damageindicator -> minecraft:damage_indicator
         add(40); // (45->40) sweepattack -> minecraft:sweep_attack
-        add(20, blockWithoutMetaHandler()); // (46->20) fallingdust -> minecraft:falling_dust
+        add(20, blockHandler()); // (46->20) fallingdust -> minecraft:falling_dust
         // BlockState	VarInt	The ID of the block state.
         add(41); // (47->41) totem -> minecraft:totem_of_undying
         add(38); // (48->38) spit -> minecraft:spit
@@ -152,19 +152,6 @@ public class ParticleRewriter {
                 int newId = WorldPackets.toNewId(combined);
 
                 particle.getArguments().add(new Particle.ParticleData(Type.VAR_INT, newId)); // BlockState	VarInt	The ID of the block state.
-                return particle;
-            }
-        };
-    }
-
-    // Handle single block ids
-    private static ParticleDataHandler blockWithoutMetaHandler() {
-        return new ParticleDataHandler() {
-            @Override
-            public Particle handler(Particle particle, Integer[] data) {
-                int blockId = data[0].shortValue() << 4;
-                int newBlockId = WorldPackets.toNewId(blockId);
-                particle.getArguments().add(new Particle.ParticleData(Type.VAR_INT, newBlockId)); // BlockState	VarInt	The ID of the block state.
                 return particle;
             }
         };

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/SpawnEggRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/SpawnEggRewriter.java
@@ -64,7 +64,8 @@ public class SpawnEggRewriter {
     public static int getSpawnEggId(String entityIdentifier) {
         // Fallback to bat
         if (!spawnEggs.containsKey(entityIdentifier))
-            return 25100288;
+            //return 25100288;
+            return -1;
         return (383 << 16 | (spawnEggs.get(entityIdentifier) & 0xFFFF));
     }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/EntityPackets.java
@@ -40,12 +40,37 @@ public class EntityPackets {
                         byte type = wrapper.get(Type.BYTE, 0);
                         Entity1_13Types.EntityType entType = Entity1_13Types.getTypeFromId(type, true);
 
-                        if (entType != null && entType.is(Entity1_13Types.EntityType.FALLING_BLOCK)) {
-                            int oldId = wrapper.get(Type.INT, 0);
-                            int combined = (((oldId & 4095) << 4) | (oldId >> 12 & 15));
-                            wrapper.set(Type.INT, 0, WorldPackets.toNewId(combined));
-                        }
+                        if (entType != null) {
+                            if (entType.is(Entity1_13Types.EntityType.FALLING_BLOCK)) {
+                                int oldId = wrapper.get(Type.INT, 0);
+                                int combined = (((oldId & 4095) << 4) | (oldId >> 12 & 15));
+                                wrapper.set(Type.INT, 0, WorldPackets.toNewId(combined));
+                            }
 
+                            // Fix ItemFrame hitbox
+                            if (entType.is(Entity1_13Types.EntityType.ITEM_FRAME)) {
+                                int data = wrapper.get(Type.INT, 0);
+
+                                switch (data) {
+                                    // South
+                                    case 0:
+                                        data = 3;
+                                        break;
+                                    // West
+                                    case 1:
+                                        data = 4;
+                                        break;
+                                    // North is the same
+                                    // East
+                                    case 3:
+                                        data = 5;
+                                        break;
+                                }
+
+                                wrapper.set(Type.INT, 0, data);
+                            }
+
+                        }
                         // Register Type ID
                         wrapper.user().get(EntityTracker.class).addEntity(entityId, entType);
                     }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -325,13 +325,31 @@ public class InventoryPackets {
                 tag.remove("ench");
                 tag.put(enchantments);
             }
+            if (tag.get("StoredEnchantments") instanceof ListTag) {
+                ListTag storedEnch = tag.get("StoredEnchantments");
+                ListTag newStoredEnch = new ListTag("StoredEnchantments", CompoundTag.class);
+                for (Tag enchEntry : storedEnch) {
+                    if (enchEntry instanceof CompoundTag) {
+                        CompoundTag enchantmentEntry = new CompoundTag("");
+                        enchantmentEntry.put(new StringTag("id",
+                                MappingData.oldEnchantmentsIds.get(
+                                        (short) ((CompoundTag) enchEntry).get("id").getValue()
+                                )
+                        ));
+                        enchantmentEntry.put(new ShortTag("lvl", (Short) ((CompoundTag) enchEntry).get("lvl").getValue()));
+                        newStoredEnch.add(enchantmentEntry);
+                    }
+                }
+                tag.remove("StoredEnchantments");
+                tag.put(newStoredEnch);
+            }
         }
 
         int rawId = (item.getId() << 4 | item.getData() & 0xF);
 
         // Handle SpawnEggs
         if (item.getId() == 383) {
-            if (tag.get("EntityTag") instanceof CompoundTag) {
+            if (tag != null && tag.get("EntityTag") instanceof CompoundTag) {
                 CompoundTag entityTag = tag.get("EntityTag");
                 if (entityTag.get("id") instanceof StringTag) {
                     StringTag identifier = entityTag.get("id");
@@ -447,7 +465,6 @@ public class InventoryPackets {
                         }
                     }
                 }
-
             }
 
             // Display Name now uses JSON
@@ -483,6 +500,27 @@ public class InventoryPackets {
                 }
                 tag.remove("Enchantment");
                 tag.put(ench);
+            }
+            if (tag.get("StoredEnchantments") instanceof ListTag) {
+                ListTag storedEnch = tag.get("StoredEnchantments");
+                ListTag newStoredEnch = new ListTag("StoredEnchantments", CompoundTag.class);
+                for (Tag enchantmentEntry : storedEnch) {
+                    if (enchantmentEntry instanceof CompoundTag) {
+                        CompoundTag enchEntry = new CompoundTag("");
+                        enchEntry.put(
+                                new ShortTag(
+                                        "id",
+                                        MappingData.oldEnchantmentsIds.inverse().get(
+                                                (String) ((CompoundTag) enchantmentEntry).get("id").getValue()
+                                        )
+                                )
+                        );
+                        enchEntry.put(new ShortTag("lvl", (Short) ((CompoundTag) enchantmentEntry).get("lvl").getValue()));
+                        newStoredEnch.add(enchEntry);
+                    }
+                }
+                tag.remove("StoredEnchantments");
+                tag.put(newStoredEnch);
             }
         }
     }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -575,6 +575,12 @@ public class InventoryPackets {
                 return "minecraft:unregister";
             case "BungeeCord":
                 return "bungeecord:main";
+            case "WDL|INIT":
+                return "wdl:init";
+            case "WDL|CONTROL":
+                return "wdl:init";
+            case "WDL|REQUEST":
+                return "wdl:request";
             default:
                 return old.matches("[0-9a-z_-]+:[0-9a-z_/.-]+") // Identifier regex
                         ? old
@@ -593,6 +599,12 @@ public class InventoryPackets {
                 return "MC|Brand";
             case "bungeecord:main":
                 return "BungeeCord";
+            case "wdl:init":
+                return "WDL|INIT";
+            case "wdl:control":
+                return "WDL|CONTROL";
+            case "wdl:request":
+                return "WDL|REQUEST";
             default:
                 return newId.startsWith("viaversion:legacy/")
                         ? new String(BaseEncoding.base32().lowerCase().withPadChar('-').decode(

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -315,12 +315,13 @@ public class InventoryPackets {
                 for (Tag enchEntry : ench) {
                     if (enchEntry instanceof CompoundTag) {
                         CompoundTag enchantmentEntry = new CompoundTag("");
-                        enchantmentEntry.put(new StringTag("id",
-                                MappingData.oldEnchantmentsIds.get(
-                                        (short) ((CompoundTag) enchEntry).get("id").getValue()
-                                )
-                        ));
-                        enchantmentEntry.put(new ShortTag("lvl", (Short) ((CompoundTag) enchEntry).get("lvl").getValue()));
+                        short oldId = ((Number) ((CompoundTag) enchEntry).get("id").getValue()).shortValue();
+                        String newId = MappingData.oldEnchantmentsIds.get(oldId);
+                        if (newId == null){
+                            newId = "viaversion:legacy/"+oldId;
+                        }
+                        enchantmentEntry.put(new StringTag("id", newId));
+                        enchantmentEntry.put(new ShortTag("lvl", ((Number) ((CompoundTag) enchEntry).get("lvl").getValue()).shortValue()));
                         enchantments.add(enchantmentEntry);
                     }
                 }
@@ -333,12 +334,15 @@ public class InventoryPackets {
                 for (Tag enchEntry : storedEnch) {
                     if (enchEntry instanceof CompoundTag) {
                         CompoundTag enchantmentEntry = new CompoundTag("");
+                        short oldId = ((Number) ((CompoundTag) enchEntry).get("id").getValue()).shortValue();
+                        String newId = MappingData.oldEnchantmentsIds.get(oldId);
+                        if (newId == null) {
+                            newId = "viaversion:legacy/"+oldId;
+                        }
                         enchantmentEntry.put(new StringTag("id",
-                                MappingData.oldEnchantmentsIds.get(
-                                        (short) ((CompoundTag) enchEntry).get("id").getValue()
-                                )
+                                newId
                         ));
-                        enchantmentEntry.put(new ShortTag("lvl", (Short) ((CompoundTag) enchEntry).get("lvl").getValue()));
+                        enchantmentEntry.put(new ShortTag("lvl", ((Number) ((CompoundTag) enchEntry).get("lvl").getValue()).shortValue()));
                         newStoredEnch.add(enchantmentEntry);
                     }
                 }
@@ -495,12 +499,15 @@ public class InventoryPackets {
                 for (Tag enchantmentEntry : enchantments) {
                     if (enchantmentEntry instanceof CompoundTag) {
                         CompoundTag enchEntry = new CompoundTag("");
+                        String newId = (String) ((CompoundTag) enchantmentEntry).get("id").getValue();
+                        Short oldId = MappingData.oldEnchantmentsIds.inverse().get(newId);
+                        if (oldId == null && newId.startsWith("viaversion:legacy/")){
+                            oldId = Short.valueOf(newId.substring(18));
+                        }
                         enchEntry.put(
                                 new ShortTag(
                                         "id",
-                                        MappingData.oldEnchantmentsIds.inverse().get(
-                                                (String) ((CompoundTag) enchantmentEntry).get("id").getValue()
-                                        )
+                                        oldId
                                 )
                         );
                         enchEntry.put(new ShortTag("lvl", (Short) ((CompoundTag) enchantmentEntry).get("lvl").getValue()));
@@ -515,13 +522,15 @@ public class InventoryPackets {
                 ListTag newStoredEnch = new ListTag("StoredEnchantments", CompoundTag.class);
                 for (Tag enchantmentEntry : storedEnch) {
                     if (enchantmentEntry instanceof CompoundTag) {
-                        CompoundTag enchEntry = new CompoundTag("");
+                        CompoundTag enchEntry = new CompoundTag("");String newId = (String) ((CompoundTag) enchantmentEntry).get("id").getValue();
+                        Short oldId = MappingData.oldEnchantmentsIds.inverse().get(newId);
+                        if (oldId == null && newId.startsWith("viaversion:legacy/")){
+                            oldId = Short.valueOf(newId.substring(18));
+                        }
                         enchEntry.put(
                                 new ShortTag(
                                         "id",
-                                        MappingData.oldEnchantmentsIds.inverse().get(
-                                                (String) ((CompoundTag) enchantmentEntry).get("id").getValue()
-                                        )
+                                        oldId
                                 )
                         );
                         enchEntry.put(new ShortTag("lvl", (Short) ((CompoundTag) enchantmentEntry).get("lvl").getValue()));

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -11,7 +11,7 @@ import us.myles.ViaVersion.api.remapper.PacketHandler;
 import us.myles.ViaVersion.api.remapper.PacketRemapper;
 import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.packets.State;
-import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.Protocol1_13To1_12_2;
+import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.ChatRewriter;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data.MappingData;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data.SoundSource;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data.SpawnEggRewriter;
@@ -299,10 +299,12 @@ public class InventoryPackets {
             }
             // Display Name now uses JSON
             if (tag.get("display") instanceof CompoundTag) {
-                if (((CompoundTag) tag.get("display")).get("Name") instanceof StringTag) {
-                    StringTag name = ((CompoundTag) tag.get("display")).get("Name");
+                CompoundTag display = tag.get("display");
+                if (display.get("Name") instanceof StringTag) {
+                    StringTag name = display.get("Name");
+                    display.put(new StringTag(NBT_TAG_NAME + "|Name", name.getValue()));
                     name.setValue(
-                            Protocol1_13To1_12_2.legacyTextToJson(
+                            ChatRewriter.legacyTextToJson(
                                     name.getValue()
                             )
                     );
@@ -482,13 +484,16 @@ public class InventoryPackets {
 
             // Display Name now uses JSON
             if (tag.get("display") instanceof CompoundTag) {
+                CompoundTag display = tag.get("display");
                 if (((CompoundTag) tag.get("display")).get("Name") instanceof StringTag) {
-                    StringTag name = ((CompoundTag) tag.get("display")).get("Name");
+                    StringTag name = display.get("Name");
+                    StringTag via = display.get(NBT_TAG_NAME + "|Name");
                     name.setValue(
-                            Protocol1_13To1_12_2.jsonTextToLegacy(
+                            via != null ? via.getValue() : ChatRewriter.jsonTextToLegacy(
                                     name.getValue()
                             )
                     );
+                    display.remove(NBT_TAG_NAME + "|Name");
                 }
             }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/InventoryPackets.java
@@ -84,7 +84,7 @@ public class InventoryPackets {
 
                             // Reset the packet
                             wrapper.clearPacket();
-                            wrapper.setId(0x4B);
+                            wrapper.setId(0x4C);
 
                             byte flags = 0;
                             wrapper.write(Type.BYTE, flags); // Placeholder

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -171,6 +171,14 @@ public class WorldPackets {
                             }
                         }
 
+                        // Rewrite biome id 255 to plains
+                        if (chunk.isBiomeData()) {
+                            for (int i = 0; i < 256; i++) {
+                                if (chunk.getBiomeData()[i] == -1)
+                                    chunk.getBiomeData()[i] = 1;
+                            }
+                        }
+
                         // Rewrite BlockEntities to normal blocks
                         BlockEntityProvider provider = Via.getManager().getProviders().get(BlockEntityProvider.class);
                         for (CompoundTag tag : chunk.getBlockEntities()) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -24,6 +24,8 @@ import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.providers.PaintingProv
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.storage.BlockStorage;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.types.Chunk1_13Type;
 
+import java.util.List;
+
 public class WorldPackets {
     public static void register(Protocol protocol) {
         // Outgoing packets
@@ -240,6 +242,24 @@ public class WorldPackets {
                         if (particle == null || particle.getId() == -1) {
                             wrapper.cancel();
                             return;
+                        }
+
+                        //Handle reddust particle color
+                        ifStatement:
+                        if (particle.getId() == 11) {
+                            int count = wrapper.get(Type.INT, 1);
+                            float speed = wrapper.get(Type.FLOAT, 6);
+                            if (count != 0 || speed != 1) break ifStatement;
+
+                            wrapper.set(Type.INT, 1, 1);
+                            wrapper.set(Type.FLOAT, 6, 0f);
+
+                            List<Particle.ParticleData> arguments = particle.getArguments();
+                            for (int i = 0; i < 3; i++) {
+                                //RGB values are represented by the X/Y/Z offset
+                                arguments.get(i).setValue(wrapper.get(Type.FLOAT, i + 3));
+                                wrapper.set(Type.FLOAT, i + 3, 0f);
+                            }
                         }
 
 //                        System.out.println("Old particle " + particleId + " " + Arrays.toString(data) +  " new Particle" + particle);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -256,11 +256,11 @@ public class WorldPackets {
     }
 
     public static int toNewId(int oldId) {
-        Integer newId = MappingData.oldToNewBlocks.get(oldId);
+        Integer newId = MappingData.blockMappings.getNewBlock(oldId);
         if (newId != null) {
             return newId;
         }
-        newId = MappingData.oldToNewBlocks.get(oldId & ~0xF); // Remove data
+        newId = MappingData.blockMappings.getNewBlock(oldId & ~0xF); // Remove data
         if (newId != null) {
             System.out.println("Missing block " + oldId);
             return newId;

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/providers/BlockEntityProvider.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/providers/BlockEntityProvider.java
@@ -2,15 +2,13 @@ package us.myles.ViaVersion.protocols.protocol1_13to1_12_2.providers;
 
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import us.myles.ViaVersion.api.PacketWrapper;
+import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.minecraft.Position;
 import us.myles.ViaVersion.api.platform.providers.Provider;
 import us.myles.ViaVersion.api.type.Type;
 import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.Protocol1_13To1_12_2;
-import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.providers.blockentities.BannerHandler;
-import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.providers.blockentities.BedHandler;
-import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.providers.blockentities.FlowerPotHandler;
-import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.providers.blockentities.SkullHandler;
+import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.providers.blockentities.*;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,6 +21,7 @@ public class BlockEntityProvider implements Provider {
         handlers.put("minecraft:bed", new BedHandler());
         handlers.put("minecraft:banner", new BannerHandler());
         handlers.put("minecraft:skull", new SkullHandler());
+        handlers.put("minecraft:mob_spawner", new SpawnerHandler());
     }
 
     /**
@@ -42,7 +41,8 @@ public class BlockEntityProvider implements Provider {
         String id = (String) tag.get("id").getValue();
 
         if (!handlers.containsKey(id)) {
-            //System.out.println("Unhandled BlockEntity " + id + " full tag: " + tag);
+            if (Via.getManager().isDebug())
+                System.out.println("Unhandled BlockEntity " + id + " full tag: " + tag);
             return -1;
         }
 
@@ -54,16 +54,16 @@ public class BlockEntityProvider implements Provider {
         return newBlock;
     }
 
-    public interface BlockEntityHandler {
-        int transform(UserConnection user, CompoundTag tag);
-    }
-
     private void sendBlockChange(UserConnection user, Position position, int blockId) throws Exception {
         PacketWrapper wrapper = new PacketWrapper(0x0B, null, user);
         wrapper.write(Type.POSITION, position);
         wrapper.write(Type.VAR_INT, blockId);
 
         wrapper.send(Protocol1_13To1_12_2.class, true, true);
+    }
+
+    public interface BlockEntityHandler {
+        int transform(UserConnection user, CompoundTag tag);
     }
 
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/providers/blockentities/FlowerPotHandler.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/providers/blockentities/FlowerPotHandler.java
@@ -52,7 +52,10 @@ public class FlowerPotHandler implements BlockEntityProvider.BlockEntityHandler 
                 ? new Pair<>(((Number) item).byteValue(), data)
                 : new Pair<>((String) item, data);
 
-        if (flowers.containsKey(pair)) {
+        // Return air on empty string
+        if (item instanceof String && ((String) item).isEmpty())
+            return 5265;
+        else if (flowers.containsKey(pair)) {
             return flowers.get(pair);
         } else if (flowersNumberId.containsKey(pair)) {
             return flowersNumberId.get(pair);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/providers/blockentities/SpawnerHandler.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/providers/blockentities/SpawnerHandler.java
@@ -1,0 +1,24 @@
+package us.myles.ViaVersion.protocols.protocol1_13to1_12_2.providers.blockentities;
+
+import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
+import com.github.steveice10.opennbt.tag.builtin.StringTag;
+import us.myles.ViaVersion.api.data.UserConnection;
+import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.data.EntityNameRewriter;
+import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.providers.BlockEntityProvider;
+
+public class SpawnerHandler implements BlockEntityProvider.BlockEntityHandler {
+    @Override
+    public int transform(UserConnection user, CompoundTag tag) {
+        if (tag.contains("SpawnData") && tag.get("SpawnData") instanceof CompoundTag) {
+            CompoundTag data = tag.get("SpawnData");
+            if (data.contains("id") && data.get("id") instanceof StringTag) {
+                StringTag s = data.get("id");
+                s.setValue(EntityNameRewriter.rewrite(s.getValue()));
+            }
+
+        }
+
+        // Always return -1 because the block is still the same id
+        return -1;
+    }
+}

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
@@ -58,7 +58,7 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
         if (groundUp) {
             for (int i = 0; i < 256; i++){
                 // todo use int in Chunk?
-                biomeData[i] = 0;
+                biomeData[i] = (byte) input.readInt();
             }
         }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/types/Chunk1_13Type.java
@@ -101,7 +101,7 @@ public class Chunk1_13Type extends PartialType<Chunk, ClientWorld> {
         // Write biome data
         if (chunk.isBiomeData()) {
             for (byte value : chunk.getBiomeData()) {
-                output.writeInt(0); // This is a temporary workaround, we'll look into fixing this soon :)
+                output.writeInt(value & 0xFF); // This is a temporary workaround, we'll look into fixing this soon :)
             }
         }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1_2to1_9_3_4/chunks/ChunkSection1_9_3_4.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_1_2to1_9_3_4/chunks/ChunkSection1_9_3_4.java
@@ -153,7 +153,11 @@ public class ChunkSection1_9_3_4 implements ChunkSection {
         }
 
         // Read blocks
-        Long[] blockData = Type.LONG_ARRAY.read(input);
+        //Long[] blockData = Type.LONG_ARRAY.read(input);
+        long[] blockData = new long[Type.VAR_INT.read(input)];
+        for (int i = 0; i < blockData.length; i++) {
+            blockData[i] = input.readLong();
+        }
         if (blockData.length > 0) {
             for (int i = 0; i < blocks.length; i++) {
                 int bitIndex = i * bitsPerBlock;
@@ -245,7 +249,7 @@ public class ChunkSection1_9_3_4 implements ChunkSection {
             }
         }
         for (long l : data) {
-            Type.LONG.write(output, l);
+            output.writeLong(l);
         }
     }
 
@@ -288,7 +292,7 @@ public class ChunkSection1_9_3_4 implements ChunkSection {
             }
         }
         for (long l : data) {
-            Type.LONG.write(output, l);
+            output.writeLong(l);
         }
     }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/chunks/ChunkSection1_9_1_2.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/chunks/ChunkSection1_9_1_2.java
@@ -145,7 +145,11 @@ public class ChunkSection1_9_1_2 implements ChunkSection {
         }
 
         // Read blocks
-        Long[] blockData = Type.LONG_ARRAY.read(input);
+        // Long[] blockData = Type.LONG_ARRAY.read(input);
+        long[] blockData = new long[Type.VAR_INT.read(input)];
+        for (int i = 0; i < blockData.length; i++) {
+            blockData[i] = input.readLong();
+        }
         if (blockData.length > 0) {
             for (int i = 0; i < blocks.length; i++) {
                 int bitIndex = i * bitsPerBlock;
@@ -237,7 +241,7 @@ public class ChunkSection1_9_1_2 implements ChunkSection {
             }
         }
         for (long l : data) {
-            Type.LONG.write(output, l);
+            output.writeLong(l);
         }
     }
 
@@ -280,7 +284,7 @@ public class ChunkSection1_9_1_2 implements ChunkSection {
             }
         }
         for (long l : data) {
-            Type.LONG.write(output, l);
+            output.writeLong(l);
         }
     }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/chunks/ChunkSection1_9to1_8.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/chunks/ChunkSection1_9to1_8.java
@@ -144,7 +144,7 @@ public class ChunkSection1_9to1_8 implements ChunkSection {
             }
         }
         for (long l : data) {
-            Type.LONG.write(output, l);
+            output.writeLong(l);
         }
     }
 
@@ -187,7 +187,7 @@ public class ChunkSection1_9to1_8 implements ChunkSection {
             }
         }
         for (long l : data) {
-            Type.LONG.write(output, l);
+            output.writeLong(l);
         }
     }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/snapshot/protocol18w30ato1_13/MetadataRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/snapshot/protocol18w30ato1_13/MetadataRewriter.java
@@ -1,0 +1,47 @@
+package us.myles.ViaVersion.protocols.snapshot.protocol18w30ato1_13;
+
+import us.myles.ViaVersion.api.Via;
+import us.myles.ViaVersion.api.data.UserConnection;
+import us.myles.ViaVersion.api.entities.Entity1_13Types;
+import us.myles.ViaVersion.api.minecraft.metadata.Metadata;
+import us.myles.ViaVersion.api.minecraft.metadata.types.MetaType1_13;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Marco Neuhaus on 28.07.2018 for the Project ViaVersion.
+ */
+public class MetadataRewriter {
+
+    public static void handleMetadata(int entityId, Entity1_13Types.EntityType type, List<Metadata> metadatas, UserConnection connection) {
+        for (Metadata metadata : new ArrayList<>(metadatas)) {
+            try {
+                if (metadata.getMetaType() == MetaType1_13.BlockID) {
+                    // Convert to new block id
+                    int data = (int) metadata.getValue();
+                    if(data > 1126){
+                        metadata.setValue(++data);
+                    }
+                }
+                if(type == null) continue;
+                if (type.isOrHasParent(Entity1_13Types.EntityType.MINECART_ABSTRACT) && metadata.getId() == 9) {
+                    // New block format
+                    int data = (int) metadata.getValue();
+                    if(data > 1126){
+                        metadata.setValue(++data);
+                    }
+                }
+                // TODO: Boat has changed
+            } catch (Exception e) {
+                metadatas.remove(metadata);
+                if (!Via.getConfig().isSuppressMetadataErrors() || Via.getManager().isDebug()) {
+                    Via.getPlatform().getLogger().warning("An error occurred with entity metadata handler");
+                    Via.getPlatform().getLogger().warning("Metadata: " + metadata);
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+}

--- a/common/src/main/java/us/myles/ViaVersion/protocols/snapshot/protocol18w30ato1_13/MetadataRewriter.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/snapshot/protocol18w30ato1_13/MetadataRewriter.java
@@ -32,7 +32,6 @@ public class MetadataRewriter {
                         metadata.setValue(++data);
                     }
                 }
-                // TODO: Boat has changed
             } catch (Exception e) {
                 metadatas.remove(metadata);
                 if (!Via.getConfig().isSuppressMetadataErrors() || Via.getManager().isDebug()) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/snapshot/protocol18w30ato1_13/Protocol18w30aTO1_13.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/snapshot/protocol18w30ato1_13/Protocol18w30aTO1_13.java
@@ -1,0 +1,365 @@
+package us.myles.ViaVersion.protocols.snapshot.protocol18w30ato1_13;
+
+import com.google.common.base.Optional;
+import us.myles.ViaVersion.api.PacketWrapper;
+import us.myles.ViaVersion.api.data.UserConnection;
+import us.myles.ViaVersion.api.entities.Entity1_13Types;
+import us.myles.ViaVersion.api.entities.Entity1_13Types.EntityType;
+import us.myles.ViaVersion.api.minecraft.BlockChangeRecord;
+import us.myles.ViaVersion.api.minecraft.chunks.Chunk;
+import us.myles.ViaVersion.api.minecraft.chunks.ChunkSection;
+import us.myles.ViaVersion.api.protocol.Protocol;
+import us.myles.ViaVersion.api.remapper.PacketHandler;
+import us.myles.ViaVersion.api.remapper.PacketRemapper;
+import us.myles.ViaVersion.api.type.Type;
+import us.myles.ViaVersion.api.type.types.version.Types1_13;
+import us.myles.ViaVersion.packets.State;
+import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.storage.EntityTracker;
+import us.myles.ViaVersion.protocols.protocol1_13to1_12_2.types.Chunk1_13Type;
+import us.myles.ViaVersion.protocols.protocol1_9_3to1_9_1_2.storage.ClientWorld;
+
+/**
+ * Created by Marco Neuhaus on 28.07.2018 for the Project ViaVersion.
+ */
+public class Protocol18w30aTO1_13 extends Protocol {
+
+    @Override
+    protected void registerPackets() {
+        //Tab complete
+        registerIncoming(State.PLAY, 0x05, 0x05, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT);
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        String s = wrapper.passthrough(Type.STRING);
+                        if(s.length() > 256){
+                            wrapper.cancel();
+                        }
+                    }
+                });
+            }
+        });
+
+        //Edit Book
+        registerIncoming(State.PLAY, 0x0B, 0x0B, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.FLAT_ITEM);
+                map(Type.BOOLEAN);
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int hand = wrapper.read(Type.VAR_INT);
+                        if(hand == 1){
+                            wrapper.cancel();
+                        }
+                    }
+                });
+            }
+        });
+
+        //Chunk
+        registerOutgoing(State.PLAY, 0x22, 0x22, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        ClientWorld clientWorld = wrapper.user().get(ClientWorld.class);
+                        Chunk chunk = wrapper.passthrough(new Chunk1_13Type(clientWorld));
+
+                        for (int i = 0; i < chunk.getSections().length; i++) {
+                            ChunkSection section = chunk.getSections()[i];
+                            if (section == null)
+                                continue;
+
+                            // TODO improve performance
+                            for (int x = 0; x < 16; x++) {
+                                for (int y = 0; y < 16; y++) {
+                                    for (int z = 0; z < 16; z++) {
+                                        int block = section.getBlock(x, y, z);
+
+                                        if(block > 1126){
+                                            section.setFlatBlock(x, y, z, ++block);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                    }
+                });
+            }
+        });
+
+        // Block Change
+        registerOutgoing(State.PLAY, 0xB, 0xB, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.POSITION);
+                map(Type.VAR_INT);
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int id = wrapper.get(Type.VAR_INT, 0);
+
+                        if(id > 1126){
+                            wrapper.set(Type.VAR_INT, 0, ++id);
+                        }
+                    }
+                });
+            }
+        });
+
+        // Multi Block Change
+        registerOutgoing(State.PLAY, 0xF, 0xF, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.INT); // 0 - Chunk X
+                map(Type.INT); // 1 - Chunk Z
+                map(Type.BLOCK_CHANGE_RECORD_ARRAY); // 2 - Records
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        // Convert ids
+                        for (BlockChangeRecord record : wrapper.get(Type.BLOCK_CHANGE_RECORD_ARRAY, 0)) {
+                            int id = record.getBlockId();
+                            if(id > 1126){
+                                record.setBlockId(++id);
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        //join game
+        registerOutgoing(State.PLAY, 0x25, 0x25, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.INT); // 0 - Entity ID
+                map(Type.UNSIGNED_BYTE); // 1 - Gamemode
+                map(Type.INT); // 2 - Dimension
+
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        // Store the player
+                        ClientWorld clientChunks = wrapper.user().get(ClientWorld.class);
+                        int dimensionId = wrapper.get(Type.INT, 1);
+                        clientChunks.setEnvironment(dimensionId);
+                    }
+                });
+            }
+        });
+
+        //respawn
+        registerOutgoing(State.PLAY, 0x38, 0x38, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.INT); // 0 - Dimension ID
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        ClientWorld clientWorld = wrapper.user().get(ClientWorld.class);
+                        int dimensionId = wrapper.get(Type.INT, 0);
+                        clientWorld.setEnvironment(dimensionId);
+                    }
+                });
+            }
+        });
+
+        //boss bar
+        registerOutgoing(State.PLAY, 0x0C, 0x0C, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.UUID);
+                map(Type.VAR_INT);
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int action = wrapper.get(Type.VAR_INT, 0);
+                        if(action == 0){
+                            wrapper.passthrough(Type.STRING);
+                            wrapper.passthrough(Type.FLOAT);
+                            wrapper.passthrough(Type.VAR_INT);
+                            short flags = wrapper.read(Type.UNSIGNED_BYTE);
+                            if ((flags & 0x02) != 0) flags |= 0x04;
+                            wrapper.write(Type.UNSIGNED_BYTE, flags);
+                        }
+                    }
+                });
+            }
+        });
+
+        //spawn particle
+        registerOutgoing(State.PLAY, 0x24, 0x24, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.INT); // 0 - Particle ID
+                map(Type.BOOLEAN); // 1 - Long Distance
+                map(Type.FLOAT); // 2 - X
+                map(Type.FLOAT); // 3 - Y
+                map(Type.FLOAT); // 4 - Z
+                map(Type.FLOAT); // 5 - Offset X
+                map(Type.FLOAT); // 6 - Offset Y
+                map(Type.FLOAT); // 7 - Offset Z
+                map(Type.FLOAT); // 8 - Particle Data
+                map(Type.INT); // 9 - Particle Count
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int id = wrapper.get(Type.INT, 0);
+                        if(id == 3 || id == 20){
+                            int data = wrapper.passthrough(Type.VAR_INT);
+                            if(data > 1126){
+                                wrapper.set(Type.VAR_INT, 0, ++data);
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        //spawn entity
+        registerOutgoing(State.PLAY, 0x0, 0x0, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT); // 0 - Entity id
+                map(Type.UUID); // 1 - UUID
+                map(Type.BYTE); // 2 - Type
+                map(Type.DOUBLE); // 3 - X
+                map(Type.DOUBLE); // 4 - Y
+                map(Type.DOUBLE); // 5 - Z
+                map(Type.BYTE); // 6 - Pitch
+                map(Type.BYTE); // 7 - Yaw
+                map(Type.INT); // 8 - Data
+
+                // Track Entity
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int entityId = wrapper.get(Type.VAR_INT, 0);
+                        byte type = wrapper.get(Type.BYTE, 0);
+                        Entity1_13Types.EntityType entType = Entity1_13Types.getTypeFromId(type, true);
+
+                        if (entType != null) {
+                            if (entType.is(Entity1_13Types.EntityType.FALLING_BLOCK)) {
+                                int data = wrapper.get(Type.INT, 0);
+                                if(data > 1126){
+                                    wrapper.set(Type.INT, 0, ++data);
+                                }
+                            }
+                        }
+                        // Register Type ID
+                        wrapper.user().get(EntityTracker.class).addEntity(entityId, entType);
+                    }
+                });
+            }
+        });
+        // Spawn mob packet
+        registerOutgoing(State.PLAY, 0x3, 0x3, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT); // 0 - Entity ID
+                map(Type.UUID); // 1 - Entity UUID
+                map(Type.VAR_INT); // 2 - Entity Type
+                map(Type.DOUBLE); // 3 - X
+                map(Type.DOUBLE); // 4 - Y
+                map(Type.DOUBLE); // 5 - Z
+                map(Type.BYTE); // 6 - Yaw
+                map(Type.BYTE); // 7 - Pitch
+                map(Type.BYTE); // 8 - Head Pitch
+                map(Type.SHORT); // 9 - Velocity X
+                map(Type.SHORT); // 10 - Velocity Y
+                map(Type.SHORT); // 11 - Velocity Z
+                map(Types1_13.METADATA_LIST); // 12 - Metadata
+
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int entityId = wrapper.get(Type.VAR_INT, 0);
+                        int type = wrapper.get(Type.VAR_INT, 1);
+
+                        Entity1_13Types.EntityType entType = Entity1_13Types.getTypeFromId(type, false);
+
+                        // Register Type ID
+                        wrapper.user().get(EntityTracker.class).addEntity(entityId, entType);
+
+                        MetadataRewriter.handleMetadata(entityId, entType, wrapper.get(Types1_13.METADATA_LIST, 0), wrapper.user());
+                    }
+                });
+            }
+        });
+
+        // Spawn player packet
+        registerOutgoing(State.PLAY, 0x05, 0x05, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT); // 0 - Entity ID
+                map(Type.UUID); // 1 - Player UUID
+                map(Type.DOUBLE); // 2 - X
+                map(Type.DOUBLE); // 3 - Y
+                map(Type.DOUBLE); // 4 - Z
+                map(Type.BYTE); // 5 - Yaw
+                map(Type.BYTE); // 6 - Pitch
+                map(Types1_13.METADATA_LIST); // 7 - Metadata
+
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int entityId = wrapper.get(Type.VAR_INT, 0);
+
+                        Entity1_13Types.EntityType entType = Entity1_13Types.EntityType.PLAYER;
+                        // Register Type ID
+                        wrapper.user().get(EntityTracker.class).addEntity(entityId, entType);
+                        MetadataRewriter.handleMetadata(entityId, entType, wrapper.get(Types1_13.METADATA_LIST, 0), wrapper.user());
+                    }
+                });
+            }
+        });
+        // Destroy entities
+        registerOutgoing(State.PLAY, 0x35, 0x35, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT_ARRAY); // 0 - Entity IDS
+
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        for (int entity : wrapper.get(Type.VAR_INT_ARRAY, 0))
+                            wrapper.user().get(EntityTracker.class).removeEntity(entity);
+                    }
+                });
+            }
+        });
+
+
+        // Metadata packet
+        registerOutgoing(State.PLAY, 0x3F, 0x3F, new PacketRemapper() {
+            @Override
+            public void registerMap() {
+                map(Type.VAR_INT); // 0 - Entity ID
+                map(Types1_13.METADATA_LIST); // 1 - Metadata list
+                handler(new PacketHandler() {
+                    @Override
+                    public void handle(PacketWrapper wrapper) throws Exception {
+                        int entityId = wrapper.get(Type.VAR_INT, 0);
+
+                        Optional<EntityType> type = wrapper.user().get(EntityTracker.class).get(entityId);
+                        MetadataRewriter.handleMetadata(entityId, type.orNull(), wrapper.get(Types1_13.METADATA_LIST, 0), wrapper.user());
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    public void init(UserConnection userConnection) {
+        userConnection.put(new EntityTracker(userConnection));
+        if (!userConnection.has(ClientWorld.class))
+            userConnection.put(new ClientWorld(userConnection));
+    }
+}

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -86,6 +86,8 @@ piston-animation-patch: false
 chat-nbt-fix: true
 # Experimental - Should we fix shift quick move action for 1.12 clients (causes shift + double click not to work when moving items) (only works on 1.8-1.11.2 bukkit based servers)
 quick-move-action-fix: false
+# Should we use prefix for team colour on 1.13 and above clients
+team-colour-fix: true
 #
 #----------------------------------------------------------#
 #         1.9 & 1.10 CLIENTS ON 1.8 SERVERS OPTIONS        #

--- a/jar/pom.xml
+++ b/jar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>viaversion-jar</name>

--- a/jar/pom.xml
+++ b/jar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0-DEV</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>viaversion-jar</name>

--- a/jar/pom.xml
+++ b/jar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>viaversion-jar</name>

--- a/jar/pom.xml
+++ b/jar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0</version>
+        <version>1.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>viaversion-jar</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>us.myles</groupId>
     <artifactId>viaversion-parent</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>viaversion-parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>us.myles</groupId>
     <artifactId>viaversion-parent</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.1</version>
     <packaging>pom</packaging>
 
     <name>viaversion-parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>us.myles</groupId>
     <artifactId>viaversion-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>viaversion-parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>us.myles</groupId>
     <artifactId>viaversion-parent</artifactId>
-    <version>1.4.0-DEV</version>
+    <version>1.4.0</version>
     <packaging>pom</packaging>
 
     <name>viaversion-parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -95,10 +95,12 @@
         </dependency>
 
         <!-- Netty (Network Library) -->
+        <!-- You should make this work with 4.0.20.Final -->
+        <!-- Using 4.0.23.Final to use Netty Collections -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.0.20.Final</version>
+            <version>4.0.23.Final</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>

--- a/sponge-legacy/pom.xml
+++ b/sponge-legacy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sponge-legacy/pom.xml
+++ b/sponge-legacy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0-DEV</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sponge-legacy/pom.xml
+++ b/sponge-legacy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0</version>
+        <version>1.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sponge-legacy/pom.xml
+++ b/sponge-legacy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0-DEV</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.0</version>
+        <version>1.4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sponge/pom.xml
+++ b/sponge/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>viaversion-parent</artifactId>
         <groupId>us.myles</groupId>
-        <version>1.4.1-SNAPSHOT</version>
+        <version>1.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeConfigAPI.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeConfigAPI.java
@@ -205,4 +205,9 @@ public class SpongeConfigAPI extends Config implements ViaVersionConfig {
     public String getReloadDisconnectMsg() {
         return getString("reload-disconnect-msg", "Server reload, please rejoin!");
     }
+
+    @Override
+    public boolean is1_13TeamColourFix() {
+        return getBoolean("team-colour-fix", true);
+    }
 }


### PR DESCRIPTION
Adding support for snapshot 18w30a and 18w30b

Changes from the Snapshots:

- Boss Bar now has separate flags for music (0x02) and fog (0x04), rather than using 0x02 for both
- Changed the max length of the text for Tab Complete (serverbound) from 256 to 32500
- Added a Hand parameter to Edit Book
- Add mapping for the new blockstate from tnt