### PR TITLE
Remove unncessary doubled map check

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/listeners/protocol1_9to1_8/HandItemCache.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/listeners/protocol1_9to1_8/HandItemCache.java
@@ -14,8 +14,6 @@ public class HandItemCache extends BukkitRunnable {
     private static Map<UUID, Item> handCache = new ConcurrentHashMap<>();
 
     public static Item getHandItem(UUID player) {
-        if (!handCache.containsKey(player))
-            return null;
         return handCache.get(player);
     }
 

--- a/sponge/src/main/java/us/myles/ViaVersion/sponge/listeners/protocol1_9to1_8/HandItemCache.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/sponge/listeners/protocol1_9to1_8/HandItemCache.java
@@ -33,8 +33,6 @@ public class HandItemCache implements Runnable {
     }
 
     public static Item getHandItem(UUID player) {
-        if (!handCache.containsKey(player))
-            return null;
         return handCache.get(player);
     }
 


### PR DESCRIPTION
These double checks can usually be simplified by removing the explicit check, as the contains check is nothing but a get() != null check.
... If accepted and plausable, I could also go over the other double checks