### PR TITLE
Faster palette

### DIFF
--- a/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/ChunkSection.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/ChunkSection.java
@@ -1,11 +1,10 @@
 package us.myles.ViaVersion.api.minecraft.chunks;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import io.netty.buffer.ByteBuf;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.List;
 
 public class ChunkSection {
     /**
@@ -17,7 +16,7 @@ public class ChunkSection {
      */
     public static final int LIGHT_LENGTH = 16 * 16 * 16 / 2; // size * size * size / 2 (nibble bit count)
     @Getter
-    private final List<Integer> palette = Lists.newArrayList();
+    private BiMap<Integer, Integer> palette = HashBiMap.create();
     private final int[] blocks;
     private NibbleArray blockLight;
     private NibbleArray skyLight;
@@ -28,7 +27,7 @@ public class ChunkSection {
     public ChunkSection() {
         this.blocks = new int[SIZE];
         this.blockLight = new NibbleArray(SIZE);
-        palette.add(0); // AIR
+        palette.put(0, 0);
     }
 
     /**
@@ -59,12 +58,12 @@ public class ChunkSection {
 
     public int getFlatBlock(int x, int y, int z) {
         int index = blocks[index(x, y, z)];
-        return palette.get(index);
+        return palette.inverse().get(index);
     }
 
     public int getFlatBlock(int idx) {
         int index = blocks[idx];
-        return palette.get(index);
+        return palette.inverse().get(index);
     }
 
     public void setBlock(int idx, int type, int data) {
@@ -87,10 +86,9 @@ public class ChunkSection {
      * @param id  The raw or flat id of the block
      */
     public void setFlatBlock(int idx, int id) {
-        int index = palette.indexOf(id);
-        if (index == -1) {
-            index = palette.size();
-            palette.add(id);
+        Integer index = palette.get(id);
+        if (index == null) {
+            palette.put(id, index = palette.size());
         }
 
         blocks[idx] = index;

--- a/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/ChunkSection.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/minecraft/chunks/ChunkSection.java
@@ -78,6 +78,24 @@ public class ChunkSection {
         return blocks[idx];
     }
 
+    public int getPaletteSize() {
+        return palette.size();
+    }
+
+    public int getPaletteEntry(int index) {
+        if (index < 0 || index >= palette.size()) throw new IndexOutOfBoundsException();
+        return palette.inverse().get(index);
+    }
+
+    public void setPaletteEntry(int index, int id) {
+        if (index < 0 || index >= palette.size()) throw new IndexOutOfBoundsException();
+        palette.forcePut(id, index);
+    }
+
+    public void replacePaletteEntry(int oldId, int newId) {
+        if (palette.containsKey(oldId)) palette.put(newId, palette.remove(oldId));
+    }
+
     /**
      * Set a block state in the chunk
      * This method will not update non-air blocks count

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_13.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_13.java
@@ -1,6 +1,5 @@
 package us.myles.ViaVersion.api.type.types.version;
 
-import com.google.common.collect.BiMap;
 import io.netty.buffer.ByteBuf;
 import us.myles.ViaVersion.api.minecraft.chunks.ChunkSection;
 import us.myles.ViaVersion.api.type.Type;
@@ -14,8 +13,6 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
     @Override
     public ChunkSection read(ByteBuf buffer) throws Exception {
         ChunkSection chunkSection = new ChunkSection();
-        BiMap<Integer, Integer> palette = chunkSection.getPalette();
-        palette.clear();
 
         // Reaad bits per block
         int bitsPerBlock = buffer.readUnsignedByte();
@@ -32,8 +29,9 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
         }
         int paletteLength = bitsPerBlock == 14 ? 0 : Type.VAR_INT.read(buffer);
         // Read palette
+        chunkSection.clearPalette();
         for (int i = 0; i < paletteLength; i++) {
-            palette.put(Type.VAR_INT.read(buffer), palette.size());
+            chunkSection.addPaletteEntry(Type.VAR_INT.read(buffer));
         }
 
         // Read blocks
@@ -68,10 +66,8 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
 
     @Override
     public void write(ByteBuf buffer, ChunkSection chunkSection) throws Exception {
-        BiMap<Integer, Integer> palette = chunkSection.getPalette();
-
         int bitsPerBlock = 4;
-        while (palette.size() > 1 << bitsPerBlock) {
+        while (chunkSection.getPaletteSize() > 1 << bitsPerBlock) {
             bitsPerBlock += 1;
         }
 
@@ -85,9 +81,9 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
 
         // Write pallet (or not)
         if (bitsPerBlock != 14) {
-            Type.VAR_INT.write(buffer, palette.size());
-            for (int i = 0; i < palette.size(); i++) {
-                Type.VAR_INT.write(buffer, palette.inverse().get(i));
+            Type.VAR_INT.write(buffer, chunkSection.getPaletteSize());
+            for (int i = 0; i < chunkSection.getPaletteSize(); i++) {
+                Type.VAR_INT.write(buffer, chunkSection.getPaletteEntry(i));
             }
         }
 

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_13.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_13.java
@@ -1,10 +1,9 @@
 package us.myles.ViaVersion.api.type.types.version;
 
+import com.google.common.collect.BiMap;
 import io.netty.buffer.ByteBuf;
 import us.myles.ViaVersion.api.minecraft.chunks.ChunkSection;
 import us.myles.ViaVersion.api.type.Type;
-
-import java.util.List;
 
 public class ChunkSectionType1_13 extends Type<ChunkSection> {
 
@@ -15,7 +14,7 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
     @Override
     public ChunkSection read(ByteBuf buffer) throws Exception {
         ChunkSection chunkSection = new ChunkSection();
-        List<Integer> palette = chunkSection.getPalette();
+        BiMap<Integer, Integer> palette = chunkSection.getPalette();
         palette.clear();
 
         // Reaad bits per block
@@ -34,7 +33,7 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
         int paletteLength = bitsPerBlock == 14 ? 0 : Type.VAR_INT.read(buffer);
         // Read palette
         for (int i = 0; i < paletteLength; i++) {
-            palette.add(Type.VAR_INT.read(buffer));
+            palette.put(Type.VAR_INT.read(buffer), palette.size());
         }
 
         // Read blocks
@@ -69,7 +68,7 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
 
     @Override
     public void write(ByteBuf buffer, ChunkSection chunkSection) throws Exception {
-        List<Integer> palette = chunkSection.getPalette();
+        BiMap<Integer, Integer> palette = chunkSection.getPalette();
 
         int bitsPerBlock = 4;
         while (palette.size() > 1 << bitsPerBlock) {
@@ -87,8 +86,8 @@ public class ChunkSectionType1_13 extends Type<ChunkSection> {
         // Write pallet (or not)
         if (bitsPerBlock != 14) {
             Type.VAR_INT.write(buffer, palette.size());
-            for (int mappedId : palette) {
-                Type.VAR_INT.write(buffer, mappedId);
+            for (int i = 0; i < palette.size(); i++) {
+                Type.VAR_INT.write(buffer, palette.inverse().get(i));
             }
         }
 

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_8.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_8.java
@@ -17,7 +17,7 @@ public class ChunkSectionType1_8 extends Type<ChunkSection> {
     @Override
     public ChunkSection read(ByteBuf buffer) throws Exception {
         ChunkSection chunkSection = new ChunkSection();
-        chunkSection.getPalette().clear();
+        chunkSection.clearPalette();
 
         byte[] blockData = new byte[ChunkSection.SIZE * 2];
         buffer.readBytes(blockData);

--- a/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_8.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/type/types/version/ChunkSectionType1_8.java
@@ -7,7 +7,6 @@ import us.myles.ViaVersion.api.type.Type;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
-import java.util.List;
 
 public class ChunkSectionType1_8 extends Type<ChunkSection> {
 
@@ -18,8 +17,7 @@ public class ChunkSectionType1_8 extends Type<ChunkSection> {
     @Override
     public ChunkSection read(ByteBuf buffer) throws Exception {
         ChunkSection chunkSection = new ChunkSection();
-        List<Integer> palette = chunkSection.getPalette();
-        palette.clear();
+        chunkSection.getPalette().clear();
 
         byte[] blockData = new byte[ChunkSection.SIZE * 2];
         buffer.readBytes(blockData);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13_1to1_13/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13_1to1_13/packets/WorldPackets.java
@@ -1,5 +1,6 @@
 package us.myles.ViaVersion.protocols.protocol1_13_1to1_13.packets;
 
+import com.google.common.collect.BiMap;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.minecraft.BlockChangeRecord;
 import us.myles.ViaVersion.api.minecraft.chunks.Chunk;
@@ -27,16 +28,12 @@ public class WorldPackets {
                         Chunk chunk = wrapper.passthrough(new Chunk1_13Type(clientWorld));
 
                         for (ChunkSection section : chunk.getSections()) {
-                            if (section != null) {
-                                for (int i = 0; i < section.getPalette().size(); i++) {
-                                    section.getPalette().set(
-                                            i,
-                                            Protocol1_13_1To1_13.getNewBlockStateId(section.getPalette().get(i))
-                                    );
-                                }
+                            if (section == null) continue;
+                            BiMap<Integer, Integer> inverse = section.getPalette().inverse();
+                            for (int i = 0; i < inverse.size(); i++) {
+                                inverse.put(i, Protocol1_13_1To1_13.getNewBlockStateId(inverse.get(i)));
                             }
                         }
-
                     }
                 });
             }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13_1to1_13/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13_1to1_13/packets/WorldPackets.java
@@ -1,6 +1,5 @@
 package us.myles.ViaVersion.protocols.protocol1_13_1to1_13.packets;
 
-import com.google.common.collect.BiMap;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.minecraft.BlockChangeRecord;
 import us.myles.ViaVersion.api.minecraft.chunks.Chunk;
@@ -29,9 +28,8 @@ public class WorldPackets {
 
                         for (ChunkSection section : chunk.getSections()) {
                             if (section == null) continue;
-                            BiMap<Integer, Integer> inverse = section.getPalette().inverse();
-                            for (int i = 0; i < inverse.size(); i++) {
-                                inverse.put(i, Protocol1_13_1To1_13.getNewBlockStateId(inverse.get(i)));
+                            for (int i = 0; i < section.getPaletteSize(); i++) {
+                                section.setPaletteEntry(i, Protocol1_13_1To1_13.getNewBlockStateId(section.getPaletteEntry(i)));
                             }
                         }
                     }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -2,6 +2,7 @@ package us.myles.ViaVersion.protocols.protocol1_13to1_12_2.packets;
 
 import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.google.common.base.Optional;
+import com.google.common.collect.BiMap;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
@@ -241,13 +242,14 @@ public class WorldPackets {
 
                             boolean willStoreAnyBlock = false;
 
-                            for (int p = 0; p < section.getPalette().size(); p++) {
-                                int old = section.getPalette().get(p);
+                            BiMap<Integer, Integer> inverse = section.getPalette().inverse();
+                            for (int p = 0; p < inverse.size(); p++) {
+                                int old = inverse.get(p);
                                 int newId = toNewId(old);
                                 if (storage.isWelcome(newId)) {
                                     willStoreAnyBlock = true;
                                 }
-                                section.getPalette().set(p, newId);
+                                inverse.put(p, newId);
                             }
 
                             if (willStoreAnyBlock) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/packets/WorldPackets.java
@@ -242,14 +242,13 @@ public class WorldPackets {
 
                             boolean willStoreAnyBlock = false;
 
-                            BiMap<Integer, Integer> inverse = section.getPalette().inverse();
-                            for (int p = 0; p < inverse.size(); p++) {
-                                int old = inverse.get(p);
+                            for (int p = 0; p < section.getPaletteSize(); p++) {
+                                int old = section.getPaletteEntry(p);
                                 int newId = toNewId(old);
                                 if (storage.isWelcome(newId)) {
                                     willStoreAnyBlock = true;
                                 }
-                                inverse.put(p, newId);
+                                section.setPaletteEntry(p, newId);
                             }
 
                             if (willStoreAnyBlock) {

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
@@ -1,5 +1,6 @@
 package us.myles.ViaVersion.protocols.protocol1_14to1_13_2.packets;
 
+import com.google.common.collect.BiMap;
 import com.google.common.primitives.Bytes;
 import io.netty.buffer.ByteBuf;
 import us.myles.ViaVersion.api.PacketWrapper;
@@ -110,13 +111,14 @@ public class WorldPackets {
                         for (ChunkSection section : chunk.getSections()) {
                             if (section == null) continue;
                             boolean hasBlock = false;
-                            for (int i = 0; i < section.getPalette().size(); i++) {
-                                int old = section.getPalette().get(i);
+                            BiMap<Integer, Integer> inverse = section.getPalette().inverse();
+                            for (int i = 0; i < inverse.size(); i++) {
+                                int old = inverse.get(i);
                                 int newId = Protocol1_14To1_13_2.getNewBlockStateId(old);
                                 if (!hasBlock && newId != AIR && newId != VOID_AIR && newId != CAVE_AIR) { // air, void_air, cave_air
                                     hasBlock = true;
                                 }
-                                section.getPalette().set(i, newId);
+                                inverse.put(i, newId);
                             }
                             if (!hasBlock) {
                                 section.setNonAirBlocksCount(0);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_14to1_13_2/packets/WorldPackets.java
@@ -111,14 +111,13 @@ public class WorldPackets {
                         for (ChunkSection section : chunk.getSections()) {
                             if (section == null) continue;
                             boolean hasBlock = false;
-                            BiMap<Integer, Integer> inverse = section.getPalette().inverse();
-                            for (int i = 0; i < inverse.size(); i++) {
-                                int old = inverse.get(i);
+                            for (int i = 0; i < section.getPaletteSize(); i++) {
+                                int old = section.getPaletteEntry(i);
                                 int newId = Protocol1_14To1_13_2.getNewBlockStateId(old);
                                 if (!hasBlock && newId != AIR && newId != VOID_AIR && newId != CAVE_AIR) { // air, void_air, cave_air
                                     hasBlock = true;
                                 }
-                                inverse.put(i, newId);
+                                section.setPaletteEntry(i, newId);
                             }
                             if (!hasBlock) {
                                 section.setNonAirBlocksCount(0);

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/types/Chunk1_9_1_2Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/types/Chunk1_9_1_2Type.java
@@ -54,8 +54,8 @@ public class Chunk1_9_1_2Type extends PartialType<Chunk, ClientWorld> {
             if (world.getEnvironment() == Environment.NORMAL) {
                 section.readSkyLight(input);
             }
-            if (replacePistons && section.getPalette().containsKey(36)) {
-                section.getPalette().put(replacementId, section.getPalette().remove(36));
+            if (replacePistons) {
+                section.replacePaletteEntry(36, replacementId);
             }
         }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/types/Chunk1_9_1_2Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9_3to1_9_1_2/types/Chunk1_9_1_2Type.java
@@ -54,10 +54,8 @@ public class Chunk1_9_1_2Type extends PartialType<Chunk, ClientWorld> {
             if (world.getEnvironment() == Environment.NORMAL) {
                 section.readSkyLight(input);
             }
-            if (replacePistons) {
-                if (section.getPalette().contains(36)) {
-                    section.getPalette().set(section.getPalette().indexOf(36), replacementId);
-                }
+            if (replacePistons && section.getPalette().containsKey(36)) {
+                section.getPalette().put(replacementId, section.getPalette().remove(36));
             }
         }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/Chunk1_9to1_8Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/Chunk1_9to1_8Type.java
@@ -89,8 +89,8 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
             ChunkSection section = Types1_8.CHUNK_SECTION.read(input);
             sections[i] = section;
 
-            if (replacePistons && section.getPalette().contains(36)) {
-                section.getPalette().set(section.getPalette().indexOf(36), replacementId);
+            if (replacePistons && section.getPalette().containsKey(36)) {
+                section.getPalette().put(replacementId, section.getPalette().remove(36));
             }
         }
 

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/Chunk1_9to1_8Type.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_9to1_8/types/Chunk1_9to1_8Type.java
@@ -89,8 +89,8 @@ public class Chunk1_9to1_8Type extends PartialType<Chunk, ClientChunks> {
             ChunkSection section = Types1_8.CHUNK_SECTION.read(input);
             sections[i] = section;
 
-            if (replacePistons && section.getPalette().containsKey(36)) {
-                section.getPalette().put(replacementId, section.getPalette().remove(36));
+            if (replacePistons) {
+                section.replacePaletteEntry(36, replacementId);
             }
         }
 


### PR DESCRIPTION
Improves performance of the palette in the ChunkSection (when setting blocks).

I did run a simple test to see the performance difference.
`ChunkSection section = new ChunkSection();

long time;
time = System.nanoTime();
for (int i = 0; i < 10000; i++) {
	section.setFlatBlock(0, 0, 0, i);
}

System.out.println(System.nanoTime() - time);

time = System.nanoTime();
for(int i = 0; i < 10000; i++) {
	section.setFlatBlock(0, 0, 0, i % 10);
}

System.out.println(System.nanoTime() - time);`

Old palette:
59922433 (= 59.9ms)
2106559 (= 2.1ms)

New palette:
5519727 (= 5.5ms, 90.7% increase)
969519 (= 1.0ms, 54.0% increase)