### PR TITLE
Add fixes for custom flowerstems and snowcollision for 1.13 clients

### DIFF
--- a/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaConfig.java
+++ b/bukkit/src/main/java/us/myles/ViaVersion/bukkit/platform/BukkitViaConfig.java
@@ -234,4 +234,14 @@ public class BukkitViaConfig extends Config implements ViaVersionConfig {
     public boolean isReduceBlockStorageMemory() {
         return getBoolean("reduce-blockstorage-memory", false);
     }
+
+    @Override
+    public boolean isStemWhenBlockAbove() {
+        return getBoolean("flowerstem-when-block-above", false);
+    }
+
+    @Override
+    public boolean isSnowCollisionFix() {
+        return getBoolean("fix-low-snow-collision", false);
+    }
 }

--- a/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
+++ b/bungee/src/main/java/us/myles/ViaVersion/bungee/platform/BungeeViaConfig.java
@@ -287,4 +287,14 @@ public class BungeeViaConfig extends Config implements ViaVersionConfig {
     public boolean isReduceBlockStorageMemory() {
         return getBoolean("reduce-blockstorage-memory", false);
     }
+
+    @Override
+    public boolean isStemWhenBlockAbove() {
+        return getBoolean("flowerstem-when-block-above", false);
+    }
+
+    @Override
+    public boolean isSnowCollisionFix() {
+        return getBoolean("fix-low-snow-collision", false);
+    }
 }

--- a/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
+++ b/common/src/main/java/us/myles/ViaVersion/api/ViaVersionConfig.java
@@ -287,4 +287,19 @@ public interface ViaVersionConfig {
      * @return True if enabled
      */
     boolean isReduceBlockStorageMemory();
+
+    /**
+     * When activated with serverside-blockconnections, flower parts with blocks above will be sent as stems.
+     * Useful for lobbyservers where users can't build and those stems are used decoratively.
+     *
+     * @return True if enabled
+     */
+    boolean isStemWhenBlockAbove();
+
+    /**
+     * When activated, the 1-layer snow will be sent as 2-layer snow to 1.13+ clients to have collision.
+     *
+     * @return True if enabled
+     */
+    boolean isSnowCollisionFix();
 }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/FlowerConnectionHandler.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/blockconnections/FlowerConnectionHandler.java
@@ -1,5 +1,6 @@
 package us.myles.ViaVersion.protocols.protocol1_13to1_12_2.blockconnections;
 
+import us.myles.ViaVersion.api.Via;
 import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.minecraft.BlockFace;
 import us.myles.ViaVersion.api.minecraft.Position;
@@ -11,10 +12,10 @@ import java.util.Set;
 
 
 public class FlowerConnectionHandler extends ConnectionHandler {
-    private static Set<String> baseFlower = new HashSet<>();
     private static Map<Integer, Integer> flowers = new HashMap<>();
 
     static void init() {
+        Set<String> baseFlower = new HashSet<>();
         baseFlower.add("minecraft:rose_bush");
         baseFlower.add("minecraft:sunflower");
         baseFlower.add("minecraft:peony");
@@ -22,9 +23,7 @@ public class FlowerConnectionHandler extends ConnectionHandler {
         baseFlower.add("minecraft:large_fern");
         baseFlower.add("minecraft:lilac");
 
-
         FlowerConnectionHandler handler = new FlowerConnectionHandler();
-
         for (Map.Entry<String, Integer> blockState : ConnectionData.keyToId.entrySet()) {
             WrappedBlockData data = WrappedBlockData.fromString(blockState.getKey());
             if (baseFlower.contains(data.getMinecraftKey())) {
@@ -40,8 +39,15 @@ public class FlowerConnectionHandler extends ConnectionHandler {
     @Override
     public int connect(UserConnection user, Position position, int blockState) {
         int blockBelowId = getBlockData(user, position.getRelative(BlockFace.BOTTOM));
-        if (flowers.containsKey(blockBelowId) && !flowers.containsKey(getBlockData(user, position.getRelative(BlockFace.TOP)))) {
-            return flowers.get(blockBelowId);
+        if (flowers.containsKey(blockBelowId)) {
+            int blockAboveId = getBlockData(user, position.getRelative(BlockFace.TOP));
+            if (Via.getConfig().isStemWhenBlockAbove()) {
+                if (blockAboveId == 0) {
+                    return flowers.get(blockBelowId);
+                }
+            } else if (!flowers.containsKey(blockAboveId)) {
+                return flowers.get(blockBelowId);
+            }
         }
         return blockState;
     }

--- a/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/MappingData.java
+++ b/common/src/main/java/us/myles/ViaVersion/protocols/protocol1_13to1_12_2/data/MappingData.java
@@ -195,6 +195,10 @@ public class MappingData {
         private BlockMappingsShortArray(JsonObject mapping1_12, JsonObject mapping1_13) {
             Arrays.fill(oldToNew, (short) -1);
             mapIdentifiers(oldToNew, mapping1_12, mapping1_13);
+            // Map minecraft:snow[layers=1] of 1.12 to minecraft:snow[layers=2] in 1.13
+            if (Via.getConfig().isSnowCollisionFix()) {
+                oldToNew[1248] = 3416;
+            }
         }
 
         @Override

--- a/common/src/main/resources/assets/viaversion/config.yml
+++ b/common/src/main/resources/assets/viaversion/config.yml
@@ -114,9 +114,21 @@ team-colour-fix: true
 suppress-1_13-conversion-errors: false
 # 1.13 introduced new auto complete which can trigger "Kicked for spamming" for servers older than 1.13, the following option will disable it completely.
 disable-1_13-auto-complete: false
+# For 1.13 clients the smallest (1 layer) snow doesn't have collision, this will send these as 2 snowlayers for 1.13+ clients to prevent them bugging through them
+fix-low-snow-collision: false
+#
+# Enable serverside block-connections for 1.13+ clients
+serverside-blockconnections: false
+# Sets the method for the block connections (world for world-level or packet for packet-level)
+blockconnection-method: world
+# When activated, only the most important blocks are stored in the blockstorage. (fences, glass panes etc. won't connect to solid blocks)
+reduce-blockstorage-memory: false
+# When activated with serverside-blockconnections, flower parts with blocks above will be sent as stems
+# Useful for lobbyservers where users can't build and those stems are used decoratively
+flowerstem-when-block-above: false
 #
 #----------------------------------------------------------#
-#         1.9 & 1.10 CLIENTS ON 1.8 SERVERS OPTIONS        #
+#             1.9+ CLIENTS ON 1.8 SERVERS OPTIONS          #
 #----------------------------------------------------------#
 #
 # No collide options, these allow you to configure how collision works.
@@ -126,7 +138,7 @@ prevent-collision: true
 auto-team: true
 # When enabled if certain metadata can't be read we won't tell you about it
 suppress-metadata-errors: false
-# When enabled 1.9 & 1.10 will be able to block by using shields
+# When enabled 1.9+ will be able to block by using shields
 shield-blocking: true
 # Enable player tick simulation, this fixes eating, drinking, nether portals.
 simulate-pt: true
@@ -134,15 +146,15 @@ simulate-pt: true
 nms-player-ticking: true
 # Should we patch boss bars so they work? (Default: true, disable if you're having issues)
 bossbar-patch: true
-# If your boss bar flickers on 1.9 & 1.10, set this to 'true'. It will keep all boss bars on 100% (not recommended)
+# If your boss bar flickers on 1.9+, set this to 'true'. It will keep all boss bars on 100% (not recommended)
 bossbar-anti-flicker: false
-# This will show the new effect indicator in the top-right corner for 1.9 & 1.10 players.
+# This will show the new effect indicator in the top-right corner for 1.9+ players.
 use-new-effect-indicator: true
-# Show the new death messages for 1.9 & 1.10 on the death screen
+# Show the new death messages for 1.9+ on the death screen
 use-new-deathmessages: true
 # Should we cache our items, this will prevent server from being lagged out, however the cost is a constant task caching items
 item-cache: true
-# Patch the Anti xray to work on 1.9 & 1.10 (If your server is 1.8) This can cost more performance, so disable it if you don't use it.
+# Patch the anti xray to work on 1.9+ (If your server is 1.8) This can cost more performance, so disable it if you don't use it.
 anti-xray-patch: true
 # Should we replace extended pistons to fix 1.10.1 (Only on chunk load)
 replace-pistons: false
@@ -152,9 +164,3 @@ replacement-piston-id: 0
 force-json-transform: false
 # Minimize the cooldown animation in 1.8 servers
 minimize-cooldown: true
-# Enable serverside block-connections for 1.13+ clients
-serverside-blockconnections: false
-# Sets the method for the block connections (world for world-level or packet for packet-level)
-blockconnection-method: world
-# When activated, only the most important blocks are stored in the blockstorage. (fences, glass panes etc. won't connect to solid blocks)
-reduce-blockstorage-memory: false

--- a/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
+++ b/sponge/src/main/java/us/myles/ViaVersion/sponge/platform/SpongeViaConfig.java
@@ -240,4 +240,14 @@ public class SpongeViaConfig extends Config implements ViaVersionConfig {
     public boolean isReduceBlockStorageMemory() {
         return getBoolean("reduce-blockstorage-memory", false);
     }
+
+    @Override
+    public boolean isStemWhenBlockAbove() {
+        return getBoolean("flowerstem-when-block-above", false);
+    }
+
+    @Override
+    public boolean isSnowCollisionFix() {
+        return getBoolean("fix-low-snow-collision", false);
+    }
 }

--- a/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
+++ b/velocity/src/main/java/us/myles/ViaVersion/velocity/platform/VelocityViaConfig.java
@@ -292,4 +292,14 @@ public class VelocityViaConfig extends Config implements ViaVersionConfig {
     public boolean isReduceBlockStorageMemory() {
         return getBoolean("reduce-blockstorage-memory", false);
     }
+
+    @Override
+    public boolean isStemWhenBlockAbove() {
+        return getBoolean("flowerstem-when-block-above", false);
+    }
+
+    @Override
+    public boolean isSnowCollisionFix() {
+        return getBoolean("fix-low-snow-collision", false);
+    }
 }


### PR DESCRIPTION
Added two (false by default) config fields: The first option fixes the lack of collision of the 1-layer snow for 1.13 clients by replacing it as 2-layers for the client (before you could stand on a 1-layer snow even if there's no block below, which is used in custom builds as well as through some world generating failures in lower versions with flying snow, which means 1.13 clients will have a hard time walking above them).

The second option is just something "nice to have" and fixes custom decorative flower stems (used by many builders, at least in Germany).
Also changed the "1.9&1.10" lines in the config to "1.9+" and moved blockconnection to the matching config section

(Images for how the stems should actually look, else the top of the sunflower stems would be the actual sunflower top -> if enabled and there is a block above, it will always be a stem, without a block just the normal flower top)
![ary9f](https://user-images.githubusercontent.com/28825609/50927763-04ff5d00-1459-11e9-90d1-eed23b151d55.png)
![ta219](https://user-images.githubusercontent.com/28825609/50927769-0892e400-1459-11e9-99f1-790bae127eed.png)